### PR TITLE
Filter medication list before validation

### DIFF
--- a/app/api/openai-diagnosis/route.ts
+++ b/app/api/openai-diagnosis/route.ts
@@ -263,7 +263,12 @@ function validateMauritiusMedicalSpecificity(analysis: any): {
   })
   
   // UK/Mauritius medication nomenclature check + DCI validation
-  const medications = analysis?.treatment_plan?.medications || []
+  const medications = (analysis?.treatment_plan?.medications || []).filter(
+    (med: any) => med && (med.drug || med.dci || med.indication || med.dosing)
+  )
+  if (analysis?.treatment_plan) {
+    analysis.treatment_plan.medications = medications
+  }
   console.log(`🧪 Validating ${medications.length} medications...`)
   
   medications.forEach((med: any, idx: number) => {


### PR DESCRIPTION
## Summary
- filter treatment plan medications to exclude empty placeholder objects before validation
- store filtered medications back onto analysis

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html2canvas)*

------
https://chatgpt.com/codex/tasks/task_e_68bad9fbb4f883278e298409af1b9d85