### PR TITLE
Filter empty medications before validation

### DIFF
--- a/app/api/openai-diagnosis/route.ts
+++ b/app/api/openai-diagnosis/route.ts
@@ -261,11 +261,16 @@ function validateMauritiusMedicalSpecificity(analysis: any): {
       suggestions.push(`Specify medical reason (e.g., "Rule out iron deficiency anaemia")`)
     }
   })
-  
+
   // UK/Mauritius medication nomenclature check + DCI validation
-  const medications = analysis?.treatment_plan?.medications || []
+  const medications = (analysis?.treatment_plan?.medications || []).filter(
+    (med: any) => med && (med.drug || med.dci || med.indication || med.dosing)
+  )
+  if (analysis?.treatment_plan?.medications) {
+    analysis.treatment_plan.medications = medications
+  }
   console.log(`🧪 Validating ${medications.length} medications...`)
-  
+
   medications.forEach((med: any, idx: number) => {
     console.log(`Medication ${idx + 1}:`, {
       drug: med?.drug,


### PR DESCRIPTION
## Summary
- Exclude placeholder medication entries before validating Mauritius-specific treatment details
- Persist filtered list back into analysis to avoid downstream placeholders

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: next not found; npm install 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68badf3b0b6083278aa627ebc1553c86