### PR TITLE
Handle non-string medication names safely

### DIFF
--- a/app/api/openai-diagnosis/route.ts
+++ b/app/api/openai-diagnosis/route.ts
@@ -231,7 +231,7 @@ For PAIN/FEVER:
 GENERATE your EXPERT medical analysis with MAXIMUM MAURITIUS MEDICAL SPECIFICITY + PRECISE DCI:`
 
 // ==================== MAURITIUS MEDICAL SPECIFICITY VALIDATION + DCI PRÉCIS ====================
-function validateMauritiusMedicalSpecificity(analysis: any): {
+export function validateMauritiusMedicalSpecificity(analysis: any): {
   hasGenericContent: boolean,
   issues: string[],
   suggestions: string[]
@@ -278,9 +278,15 @@ function validateMauritiusMedicalSpecificity(analysis: any): {
       indication: med?.indication,
       dosing_adult: med?.dosing?.adult
     })
-    
+
     // Extraction intelligente si GPT-4 a mélangé drug + dosing
-    let cleanDrugName = med?.drug || ''
+    let cleanDrugName: string
+    try {
+      cleanDrugName = String(med?.drug || '')
+    } catch (err) {
+      console.warn(`⚠️ Skipping medication ${idx + 1}: unable to stringify drug`, err)
+      return
+    }
     let extractedDosing = med?.dosing?.adult || ''
     
     // Si le dosing est dans le nom du médicament, l'extraire

--- a/test/validateMauritiusMedicalSpecificity.test.ts
+++ b/test/validateMauritiusMedicalSpecificity.test.ts
@@ -1,0 +1,34 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { validateMauritiusMedicalSpecificity } from '../app/api/openai-diagnosis/route'
+
+test('handles non-stringifiable med.drug gracefully', () => {
+  const problematicDrug = {
+    toString() {
+      throw new Error('cannot stringify')
+    }
+  }
+
+  const analysis = {
+    treatment_plan: {
+      medications: [
+        {
+          drug: problematicDrug,
+          dci: 'Amoxicilline',
+          indication: 'Treatment of infection',
+          dosing: {
+            adult: '500mg BD',
+            daily_total_dose: '1000mg',
+            frequency_per_day: 2
+          }
+        }
+      ]
+    }
+  }
+
+  let result: any
+  assert.doesNotThrow(() => {
+    result = validateMauritiusMedicalSpecificity(analysis)
+  })
+  assert.equal(result.issues.length, 0)
+})


### PR DESCRIPTION
## Summary
- Safely convert `med.drug` to a string in `validateMauritiusMedicalSpecificity`
- Skip validation and log a warning when `med.drug` cannot be stringified
- Add regression test covering an object `med.drug`

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --test test/validateMauritiusMedicalSpecificity.test.ts` *(fails: Unknown file extension ".ts")*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baea8a951083279522d2b6cab5f7ad