### PR TITLE
Handle missing chief complaint in consultation type analysis

### DIFF
--- a/app/api/openai-diagnosis/route.ts
+++ b/app/api/openai-diagnosis/route.ts
@@ -1704,9 +1704,9 @@ function applySafetyCorrections(analysis: any, issue: any): number {
 }
 
 // ==================== MEDICATION MANAGEMENT (CONSERVÉ) ====================
-function analyzeConsultationType(
+export function analyzeConsultationType(
   currentMedications: string[],
-  chiefComplaint: string,
+  chiefComplaint: unknown,
   symptoms: string[]
 ): {
   consultationType: 'renewal' | 'new_problem' | 'mixed';
@@ -1718,8 +1718,13 @@ function analyzeConsultationType(
     'renewal', 'refill', 'same medication', 'usual', 'chronic', 'chronique',
     'prescription', 'continue', 'poursuivre', 'maintenir', 'repeat'
   ];
-  
-  const chiefComplaintLower = chiefComplaint.toLowerCase();
+
+  if (typeof chiefComplaint !== 'string') {
+    console.warn('analyzeConsultationType expected chiefComplaint to be a string');
+  }
+  const chiefComplaintStr =
+    typeof chiefComplaint === 'string' ? chiefComplaint : '';
+  const chiefComplaintLower = chiefComplaintStr.toLowerCase();
   const symptomsLower = symptoms.join(' ').toLowerCase();
   const allText = `${chiefComplaintLower} ${symptomsLower}`;
   

--- a/tests/analyzeConsultationType.test.ts
+++ b/tests/analyzeConsultationType.test.ts
@@ -1,0 +1,10 @@
+import { analyzeConsultationType } from '../app/api/openai-diagnosis/route'
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+
+describe('analyzeConsultationType', () => {
+  it('handles missing chiefComplaint', () => {
+    const result = analyzeConsultationType([], undefined as any, [])
+    assert.strictEqual(result.consultationType, 'new_problem')
+  })
+})


### PR DESCRIPTION
## Summary
- Safely handle undefined `chiefComplaint` and warn when it isn't a string
- Add test ensuring `analyzeConsultationType` works without a chief complaint

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html2canvas)*
- `node --test tests/analyzeConsultationType.test.ts` *(fails: Unknown file extension ".ts" for tests/analyzeConsultationType.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68baea8cd2808327a0785da5dcb74bf2