### PR TITLE
Handle non-string medication duration

### DIFF
--- a/app/api/openai-diagnosis/route.ts
+++ b/app/api/openai-diagnosis/route.ts
@@ -1318,7 +1318,7 @@ function validateDiagnosticProcess(analysis: any) {
   return { issues }
 }
 
-function validateTherapeuticCompleteness(analysis: any, patientContext: PatientContext) {
+export function validateTherapeuticCompleteness(analysis: any, patientContext: PatientContext) {
   const issues: Array<{type: 'critical'|'important'|'minor', category: string, description: string, suggestion: string}> = []
   const medications = analysis?.treatment_plan?.medications || []
   
@@ -1363,11 +1363,16 @@ function validateTherapeuticCompleteness(analysis: any, patientContext: PatientC
       completenessScore -= 15
     }
     
-    const duration = med?.duration || ''
+    const rawDuration = med?.duration
+    const duration = String(rawDuration || '')
+    if (rawDuration != null && typeof rawDuration !== 'string') {
+      console.warn(`Non-string duration for ${med?.drug || `medication ${idx+1}`}:`, rawDuration)
+      return
+    }
     if (!duration || duration.toLowerCase().includes('as needed') || duration.toLowerCase().includes('selon')) {
       issues.push({
         type: 'important',
-        category: 'therapeutic', 
+        category: 'therapeutic',
         description: `Imprecise duration for ${med?.drug || `medication ${idx+1}`}`,
         suggestion: 'Specify treatment duration (days/weeks/months)'
       })

--- a/tests/validateTherapeuticCompleteness.test.ts
+++ b/tests/validateTherapeuticCompleteness.test.ts
@@ -1,0 +1,40 @@
+import assert from 'node:assert/strict'
+import { validateTherapeuticCompleteness } from '../app/api/openai-diagnosis/route'
+
+const patientContext = {
+  age: 30,
+  sex: 'male',
+  medical_history: [],
+  current_medications: [],
+  allergies: [],
+  chief_complaint: '',
+  symptoms: [],
+  symptom_duration: '',
+  disease_history: '',
+  ai_questions: []
+}
+
+const analysis = {
+  treatment_plan: {
+    medications: [
+      {
+        drug: 'SampleDrug',
+        dci: 'sample',
+        dosing: { adult: '100mg' },
+        duration: { start: 'today', end: 'tomorrow' }
+      }
+    ]
+  },
+  clinical_analysis: { primary_diagnosis: { condition: 'condition' } }
+}
+
+let warned = false
+const originalWarn = console.warn
+console.warn = () => { warned = true }
+
+const result = validateTherapeuticCompleteness(analysis, patientContext)
+
+console.warn = originalWarn
+
+assert.equal(warned, true)
+assert.equal(result.issues.length, 0)


### PR DESCRIPTION
## Summary
- Safely coerce medication duration to string before checks
- Warn and skip validation on non-string duration values
- Add regression test for object duration entries

## Testing
- `npx ts-node tests/validateTherapeuticCompleteness.test.ts` (fails: 403 Forbidden from npm registry)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68baea8ff5848327b08851abc75987ad