### PR TITLE
feat: allow gram dosages in medication validation

### DIFF
--- a/app/api/openai-diagnosis/route.ts
+++ b/app/api/openai-diagnosis/route.ts
@@ -307,7 +307,7 @@ function validateMauritiusMedicalSpecificity(analysis: any): {
         drugName.includes('medication') ||
         drugName.includes('médicament') ||
         drugName.length < 5 ||
-        !drugName.match(/\d+\s*m[cg]/)) {  // Must contain UK dosage (mg/mcg)
+        !drugName.match(/\d+\s*(mg|mcg|g)/i)) {  // Must contain UK dosage (mg/mcg/g)
       issues.push(`Medication ${idx + 1}: Generic/missing name "${med?.drug || 'undefined'}"`)
       suggestions.push(`Use UK nomenclature with dose (e.g., "Amoxicilline 500mg", "Ibuprofène 400mg")`)
     }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "next build",
     "dev": "next dev",
     "lint": "next lint",
-    "start": "next start"
+    "start": "next start",
+    "test": "node --test"
   },
   "dependencies": {
     "@ai-sdk/openai": "latest",

--- a/tests/validateMauritiusMedicalSpecificity.test.js
+++ b/tests/validateMauritiusMedicalSpecificity.test.js
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'fs';
+import path from 'path';
+
+// Extract the dosage regex from the source file to ensure tests reflect implementation.
+const routePath = path.join(process.cwd(), 'app', 'api', 'openai-diagnosis', 'route.ts');
+const source = fs.readFileSync(routePath, 'utf8');
+const match = source.match(/drugName\.match\((\/.*?\/[a-z]*)\)/);
+if (!match) {
+  throw new Error('Dosage regex not found in route.ts');
+}
+const dosageRegex = eval(match[1]);
+
+test('1g is accepted by generic-name validation', () => {
+  assert.ok(dosageRegex.test('1g'));
+});
+
+test('500 mg is accepted by generic-name validation', () => {
+  assert.ok(dosageRegex.test('500 mg'));
+});


### PR DESCRIPTION
## Summary
- update generic-name validation to accept gram dosages
- add tests for 1g and 500 mg dosage recognition

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baea8dcdac83278a386b97dc40b2db