### PR TITLE
fix(patient-pdf): ship evidence_references + indication on TIBOK payload

### DIFF
--- a/components/chronic-disease/chronic-professional-report-v2.tsx
+++ b/components/chronic-disease/chronic-professional-report-v2.tsx
@@ -2877,6 +2877,11 @@ const handleSendDocuments = async () => {
  type: 'consultation_report',
  title: 'Medical Consultation Report',
  content: report.compteRendu,
+ // Bug 1 (parity with general flow): ship medical guideline references
+ // so the patient PDF can render the bibliography section.
+ evidenceReferences: Array.isArray((diagnosisData as any)?.evidence_references)
+   ? (diagnosisData as any).evidence_references
+   : [],
  validated: true,
  validatedAt: report.compteRendu.metadata?.validatedAt || new Date().toISOString(),
  signature: documentSignatures?.consultation || null
@@ -2884,7 +2889,12 @@ const handleSendDocuments = async () => {
  prescriptions: report?.ordonnances?.medicaments ? {
  type: 'prescription',
  title: 'Medical Prescription',
- medications: report.ordonnances.medicaments.prescription?.medicaments || [],
+ // Bug 2 (parity with general flow): mirror `justification` as
+ // `indication` so the prescription PDF template can render it.
+ medications: (report.ordonnances.medicaments.prescription?.medicaments || []).map((m: any) => ({
+   ...m,
+   indication: m?.indication || m?.justification || '',
+ })),
  validity: report.ordonnances.medicaments.prescription?.validite || '3 months',
  signature: documentSignatures?.prescription || null,
  content: report.ordonnances.medicaments

--- a/components/chronic-disease/chronic-professional-report.tsx
+++ b/components/chronic-disease/chronic-professional-report.tsx
@@ -2956,6 +2956,11 @@ export default function ChronicProfessionalReport({
             type: 'chronic_disease_report',
             title: 'Chronic Disease Follow-up Consultation Report',
             content: report.medicalReport,
+            // Bug 1 (parity with general flow): ship medical guideline
+            // references so the patient PDF can render the bibliography.
+            evidenceReferences: Array.isArray((diagnosisData as any)?.evidence_references)
+              ? (diagnosisData as any).evidence_references
+              : [],
             validated: true,
             validatedAt: new Date().toISOString(),
             signature: documentSignatures?.consultation || null
@@ -2963,7 +2968,12 @@ export default function ChronicProfessionalReport({
           prescriptions: report?.medicationPrescription ? {
             type: 'prescription',
             title: 'Medication Prescription',
-            medications: report.medicationPrescription.prescription?.medications || [],
+            // Bug 2 (parity with general flow): mirror `justification` as
+            // `indication` so the prescription PDF template can render it.
+            medications: (report.medicationPrescription.prescription?.medications || []).map((m: any) => ({
+              ...m,
+              indication: m?.indication || m?.justification || '',
+            })),
             validity: report.medicationPrescription.prescription?.validity || '3 months',
             signature: documentSignatures?.prescription || null,
             content: report.medicationPrescription

--- a/components/dermatology/dermatology-professional-report.tsx
+++ b/components/dermatology/dermatology-professional-report.tsx
@@ -3817,6 +3817,11 @@ isEmergency: isEmergencyCase,
  type: 'consultation_report',
  title: 'Medical Consultation Report',
  content: report.compteRendu,
+ // Bug 1 (parity with general flow): ship medical guideline references
+ // so the patient PDF can render the bibliography section.
+ evidenceReferences: Array.isArray(diagnosisData?.evidence_references)
+   ? diagnosisData.evidence_references
+   : [],
  validated: true,
  validatedAt: report.compteRendu.metadata?.validatedAt || new Date().toISOString(),
  signature: documentSignatures?.consultation || null
@@ -3824,7 +3829,12 @@ isEmergency: isEmergencyCase,
  prescriptions: report?.ordonnances?.medicaments ? {
  type: 'prescription',
  title: 'Medical Prescription',
- medications: report.ordonnances.medicaments.prescription?.medicaments || [],
+ // Bug 2 (parity with general flow): mirror `justification` as
+ // `indication` so the prescription PDF template can render it.
+ medications: (report.ordonnances.medicaments.prescription?.medicaments || []).map((m: any) => ({
+   ...m,
+   indication: m?.indication || m?.justification || '',
+ })),
  validity: report.ordonnances.medicaments.prescription?.validite || '3 months',
  signature: documentSignatures?.prescription || null,
  content: report.ordonnances.medicaments

--- a/components/professional-report.tsx
+++ b/components/professional-report.tsx
@@ -3859,6 +3859,14 @@ const handleSendDocuments = async () => {
  type: 'consultation_report',
  title: 'Medical Consultation Report',
  content: report.compteRendu,
+ // Bug 1: ship the medical guideline references with the consultation
+ // report so the patient PDF can render the "Références médicales
+ // utilisées" section at the bottom (between the narrative and the QR
+ // verification block). Prescriptions/labs/imaging keep the inline
+ // "(Source, Year)" form only — the full bibliography lives here.
+ evidenceReferences: Array.isArray(diagnosisData?.evidence_references)
+   ? diagnosisData.evidence_references
+   : [],
  validated: true,
  validatedAt: report.compteRendu.metadata?.validatedAt || new Date().toISOString(),
  signature: documentSignatures?.consultation || null
@@ -3866,7 +3874,15 @@ const handleSendDocuments = async () => {
  prescriptions: report?.ordonnances?.medicaments ? {
  type: 'prescription',
  title: 'Medical Prescription',
- medications: report.ordonnances.medicaments.prescription?.medicaments || [],
+ // Bug 2: each medication needs an `indication` field for the TIBOK
+ // prescription PDF template. Locally we render `med.justification`
+ // (set from `med.indication` upstream at the report-mapping step), so
+ // mirror it back as `indication` for the patient-facing payload while
+ // keeping `justification` for backwards compatibility.
+ medications: (report.ordonnances.medicaments.prescription?.medicaments || []).map((m: any) => ({
+   ...m,
+   indication: m?.indication || m?.justification || '',
+ })),
  validity: report.ordonnances.medicaments.prescription?.validite || '3 months',
  signature: documentSignatures?.prescription || null,
  content: report.ordonnances.medicaments


### PR DESCRIPTION
Patient-facing PDFs are rendered on the TIBOK side from the documents payload AI-DOCTOR posts to /api/send-to-patient-dashboard. Two fields were missing from that payload, so the TIBOK templates had nothing to render even though the data was available locally.

Bug 1 — "Références médicales utilisées" missing from Medical Report PDF The consultationReport block sent only `content: report.compteRendu`, which doesn't carry the bibliography. Add an explicit `evidenceReferences` field on the same object, populated from diagnosisData.evidence_references (the same array the on-screen EvidenceReferencesSection already uses), so the patient PDF template can render the section between the narrative and the QR verification block.

Bug 2 — Indication missing under each medication on Prescription PDF The locally rendered prescription card reads `med.justification` (set upstream from `med.indication` at the report mapping step in professional-report.tsx L2465). The TIBOK template expects the canonical `med.indication` field. Mirror `justification` as `indication` on each prescription medication entry so the patient PDF shows the indication text (which now contains the "(Source, Year)" inline citation produced by the dual-format expansion at 5d0f3d0). Keep `justification` in place for backwards compatibility.

Lab + radiology PDFs are not changed — the user explicitly wants these to keep only the inline (Source, Year) and no bibliography.

Applied to all four flows that post to send-to-patient-dashboard:
- components/professional-report.tsx (general consultation)
- components/dermatology/dermatology-professional-report.tsx
- components/chronic-disease/chronic-professional-report.tsx
- components/chronic-disease/chronic-professional-report-v2.tsx