### PR TITLE
chore(patient-pdf): instrument TIBOK payload for evidenceReferences gap

### DIFF
--- a/components/chronic-disease/chronic-professional-report-v2.tsx
+++ b/components/chronic-disease/chronic-professional-report-v2.tsx
@@ -2942,6 +2942,27 @@ sickLeaveCertificate: report?.ordonnances?.arretMaladie ? {
  console.log('📨 Sending to Tibok at:', tibokUrl)
  console.log('📦 Payload size:', JSON.stringify(documentsPayload).length, 'bytes')
 
+ // Diagnostic: confirm evidenceReferences + medication.indication actually
+ // reach the payload sent to TIBOK.
+ try {
+   const cr = (documentsPayload as any).documents?.consultationReport
+   const rx = (documentsPayload as any).documents?.prescriptions
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] consultationReport keys:',
+               cr ? Object.keys(cr) : '(consultationReport is null)')
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] evidenceReferences length:',
+               cr?.evidenceReferences?.length)
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] first ref:',
+               cr?.evidenceReferences?.[0])
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] diagnosisData.evidence_references length:',
+               (diagnosisData as any)?.evidence_references?.length)
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] prescriptions.medications[0] keys:',
+               rx?.medications?.[0] ? Object.keys(rx.medications[0]) : '(no medications)')
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] prescriptions.medications[0].indication:',
+               rx?.medications?.[0]?.indication?.slice?.(0, 200))
+ } catch (dbgErr: any) {
+   console.error('🔍 [DEBUG-AIDOC-PAYLOAD] instrumentation error (non-blocking):', dbgErr?.message || dbgErr)
+ }
+
  const response = await fetch(`${tibokUrl}/api/send-to-patient-dashboard`, {
  method: 'POST',
  headers: { 'Content-Type': 'application/json' },

--- a/components/chronic-disease/chronic-professional-report.tsx
+++ b/components/chronic-disease/chronic-professional-report.tsx
@@ -3037,6 +3037,27 @@ export default function ChronicProfessionalReport({
       console.log('📨 Sending chronic disease documents to Tibok at:', tibokUrl)
       console.log('📦 Payload size:', JSON.stringify(documentsPayload).length, 'bytes')
 
+      // Diagnostic: confirm evidenceReferences + medication.indication actually
+      // reach the payload sent to TIBOK.
+      try {
+        const cr = (documentsPayload as any).documents?.consultationReport
+        const rx = (documentsPayload as any).documents?.prescriptions
+        console.log('🔍 [DEBUG-AIDOC-PAYLOAD] consultationReport keys:',
+                    cr ? Object.keys(cr) : '(consultationReport is null)')
+        console.log('🔍 [DEBUG-AIDOC-PAYLOAD] evidenceReferences length:',
+                    cr?.evidenceReferences?.length)
+        console.log('🔍 [DEBUG-AIDOC-PAYLOAD] first ref:',
+                    cr?.evidenceReferences?.[0])
+        console.log('🔍 [DEBUG-AIDOC-PAYLOAD] diagnosisData.evidence_references length:',
+                    (diagnosisData as any)?.evidence_references?.length)
+        console.log('🔍 [DEBUG-AIDOC-PAYLOAD] prescriptions.medications[0] keys:',
+                    rx?.medications?.[0] ? Object.keys(rx.medications[0]) : '(no medications)')
+        console.log('🔍 [DEBUG-AIDOC-PAYLOAD] prescriptions.medications[0].indication:',
+                    rx?.medications?.[0]?.indication?.slice?.(0, 200))
+      } catch (dbgErr: any) {
+        console.error('🔍 [DEBUG-AIDOC-PAYLOAD] instrumentation error (non-blocking):', dbgErr?.message || dbgErr)
+      }
+
       // Send to dedicated chronic disease documents endpoint
       const response = await fetch(`${tibokUrl}/api/chronic-disease-documents`, {
         method: 'POST',

--- a/components/dermatology/dermatology-professional-report.tsx
+++ b/components/dermatology/dermatology-professional-report.tsx
@@ -3905,6 +3905,27 @@ console.log('👤 Patient data in payload:', documentsPayload.patientData)
    console.log('📦 Reduced payload size:', Math.round(JSON.stringify(documentsPayload).length / 1024), 'KB')
  }
 
+ // Diagnostic: confirm evidenceReferences + medication.indication actually
+ // reach the payload sent to TIBOK.
+ try {
+   const cr = (documentsPayload as any).documents?.consultationReport
+   const rx = (documentsPayload as any).documents?.prescriptions
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] consultationReport keys:',
+               cr ? Object.keys(cr) : '(consultationReport is null)')
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] evidenceReferences length:',
+               cr?.evidenceReferences?.length)
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] first ref:',
+               cr?.evidenceReferences?.[0])
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] diagnosisData.evidence_references length:',
+               (diagnosisData as any)?.evidence_references?.length)
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] prescriptions.medications[0] keys:',
+               rx?.medications?.[0] ? Object.keys(rx.medications[0]) : '(no medications)')
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] prescriptions.medications[0].indication:',
+               rx?.medications?.[0]?.indication?.slice?.(0, 200))
+ } catch (dbgErr: any) {
+   console.error('🔍 [DEBUG-AIDOC-PAYLOAD] instrumentation error (non-blocking):', dbgErr?.message || dbgErr)
+ }
+
  // Send to dedicated dermatology documents endpoint
  const response = await fetch(`${tibokUrl}/api/dermatology-documents`, {
  method: 'POST',

--- a/components/professional-report.tsx
+++ b/components/professional-report.tsx
@@ -3940,6 +3940,28 @@ sickLeaveCertificate: report?.ordonnances?.arretMaladie ? {
  console.log('📨 Sending to Tibok at:', tibokUrl)
  console.log('📦 Payload size:', JSON.stringify(documentsPayload).length, 'bytes')
 
+ // Diagnostic: confirm evidenceReferences + medication.indication actually
+ // reach the payload sent to TIBOK. If a field is missing here, it cannot
+ // be the TIBOK route handler's fault.
+ try {
+   const cr = (documentsPayload as any).documents?.consultationReport
+   const rx = (documentsPayload as any).documents?.prescriptions
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] consultationReport keys:',
+               cr ? Object.keys(cr) : '(consultationReport is null)')
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] evidenceReferences length:',
+               cr?.evidenceReferences?.length)
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] first ref:',
+               cr?.evidenceReferences?.[0])
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] diagnosisData.evidence_references length:',
+               (diagnosisData as any)?.evidence_references?.length)
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] prescriptions.medications[0] keys:',
+               rx?.medications?.[0] ? Object.keys(rx.medications[0]) : '(no medications)')
+   console.log('🔍 [DEBUG-AIDOC-PAYLOAD] prescriptions.medications[0].indication:',
+               rx?.medications?.[0]?.indication?.slice?.(0, 200))
+ } catch (dbgErr: any) {
+   console.error('🔍 [DEBUG-AIDOC-PAYLOAD] instrumentation error (non-blocking):', dbgErr?.message || dbgErr)
+ }
+
  // Call Tibok endpoint for ALL consultation types
  const response = await fetch(`${tibokUrl}/api/send-to-patient-dashboard`, {
  method: 'POST',


### PR DESCRIPTION
Patient PDF on TIBOK has documents_data.consultation_report.evidence References = NULL despite the field being added to the payload at 4c05ad9 (meds.indication is shipping correctly, so part of that commit landed).

Pure instrumentation, zero behavioural change. Add 6 console.log lines right before each fetch() to /api/send-to-patient-dashboard, /api/dermatology-documents, /api/chronic-disease-documents, in all four flows that post to TIBOK:
- consultationReport keys
- consultationReport.evidenceReferences length + first entry
- diagnosisData.evidence_references length (upstream value)
- prescriptions.medications[0] keys
- prescriptions.medications[0].indication preview

Diagnostic matrix once Megane reruns:
- evidenceReferences length non-zero in AI-DOCTOR logs but NULL in TIBOK DB → bug in TIBOK route handler (doesn't destructure the field)
- evidenceReferences length zero/undefined here but diagnosisData.evidence_references length non-zero → bug in payload construction (the assignment isn't effective)
- Both zero/undefined → diagnosisData.evidence_references not reaching this component, trace upstream