### PR TITLE
Phase 2.D.B.1: persist role + nurse params in sessionStorage from hub…

### DIFF
--- a/app/consultation-hub/page.tsx
+++ b/app/consultation-hub/page.tsx
@@ -60,12 +60,92 @@ export default function ConsultationHubPage() {
         sessionStorage.removeItem('fromConsultationHub')
         // Clear previous simulation flag
         sessionStorage.removeItem('isSimulation')
+        // Phase 2.D.B.1: clear hybrid-mode + nurse-led keys too. Without
+        // this, a stale tibokRole='nurse' from an earlier nurse-led consult
+        // would survive into a new doctor consult and trigger gating.
+        sessionStorage.removeItem('tibokConsultationMode')
+        sessionStorage.removeItem('tibokPresentialActor')
+        sessionStorage.removeItem('tibokRole')
+        sessionStorage.removeItem('tibokNurseId')
+        sessionStorage.removeItem('tibokNurseInfo')
+        sessionStorage.removeItem('tibokHandoffState')
       }
 
       // SIMULATION MODE: Store flag and use consultationType from URL directly
       if (isSimulation) {
         console.log('🎮 SIMULATION MODE detected — consultationType:', simConsultationType)
         sessionStorage.setItem('isSimulation', 'true')
+      }
+
+      // Phase 2.D.B.1 — Persist hybrid-mode + nurse-led params NOW.
+      //
+      // Why here instead of (only) hooks/use-tibok-patient-data.ts:
+      // The hub is the actual TIBOK landing page. After the doctor/nurse
+      // clicks "Continuer →", HubWorkflowSelector calls router.push('/')
+      // (or '/chronic-disease', '/dermatology') WITHOUT preserving query
+      // params (components/consultation-hub/hub-workflow-selector.tsx:315).
+      // The downstream pages then see a bare URL — use-tibok-patient-data
+      // running on / finds nothing in URL params and never sets sessionStorage.
+      // Persisting here, before the navigation, is the only way these params
+      // survive the hub → workflow transition.
+      const roleParam = urlParams.get('role')
+      if (roleParam === 'doctor' || roleParam === 'nurse') {
+        sessionStorage.setItem('tibokRole', roleParam)
+        console.log('👤 [Hub] TIBOK role:', roleParam)
+      }
+
+      const nurseIdParam = urlParams.get('nurseId')
+      if (nurseIdParam) {
+        sessionStorage.setItem('tibokNurseId', nurseIdParam)
+        console.log('👩‍⚕️ [Hub] TIBOK nurse ID:', nurseIdParam)
+      }
+
+      const nurseDataParam = urlParams.get('nurseData')
+      if (nurseDataParam) {
+        // Same decode-retry pattern this hub uses for doctorData (L91-118):
+        // decodeURIComponent up to 5×, trim trailing junk after the last '}',
+        // JSON.parse.
+        let decodedNurse = nurseDataParam
+        let nurseInfo: any = null
+        for (let attempt = 1; attempt <= 5; attempt++) {
+          try {
+            decodedNurse = decodeURIComponent(decodedNurse)
+            if (decodedNurse.startsWith('{')) {
+              const lastBrace = decodedNurse.lastIndexOf('}')
+              const jsonString = lastBrace !== -1
+                ? decodedNurse.slice(0, lastBrace + 1)
+                : decodedNurse
+              nurseInfo = JSON.parse(jsonString)
+              break
+            }
+          } catch {
+            // keep decoding
+          }
+        }
+        if (nurseInfo) {
+          sessionStorage.setItem('tibokNurseInfo', JSON.stringify(nurseInfo))
+          console.log('👩‍⚕️ [Hub] TIBOK nurse info:',
+            nurseInfo.fullName || nurseInfo.full_name || nurseInfo.id || '(unnamed)')
+        } else {
+          console.warn('👩‍⚕️ [Hub] nurseData present but failed to decode after 5 attempts')
+        }
+      }
+
+      // Phase 1 hybrid params (consultationMode, presentialActor) — duplicate
+      // the writes here so they survive the hub → workflow navigation too.
+      // hooks/use-tibok-patient-data.ts on the workflow page will be a no-op
+      // when the URL is bare; reading from sessionStorage is the path that
+      // actually carries through.
+      const consultationModeParam = urlParams.get('consultationMode')
+      if (consultationModeParam) {
+        sessionStorage.setItem('tibokConsultationMode', consultationModeParam)
+        console.log('🏥 [Hub] TIBOK consultation mode:', consultationModeParam)
+      }
+
+      const presentialActorParam = urlParams.get('presentialActor')
+      if (presentialActorParam) {
+        sessionStorage.setItem('tibokPresentialActor', presentialActorParam)
+        console.log('👤 [Hub] TIBOK presential actor:', presentialActorParam)
       }
 
       // Extract and save doctor data from URL params


### PR DESCRIPTION
… (survives hub → / navigation)

Bug: a nurse-led general consultation (dc87c84d-cffe-4187-ae7a-d543038f00eb) landed on the hub with ?role=nurse&nurseId=...&nurseData=..., then the "Continuer →" button drove HubWorkflowSelector to call router.push('/') WITHOUT query-param preservation (components/consultation-hub/ hub-workflow-selector.tsx:315). On /, hooks/use-tibok-patient-data.ts ran on a bare URL, found nothing, never set sessionStorage. The nurse saw all 5 steps of the doctor flow with full edit access — critical.

Root cause: the nurse-led params (role, nurseId, nurseData) and the Phase 1 hybrid params (consultationMode, presentialActor) were only written to sessionStorage by a hook running on /. The hub itself never persisted them, so they evaporated as soon as the user navigated away with stripped query params.

Fix in app/consultation-hub/page.tsx, in the existing init useEffect:

1) Extend the fresh-consultation clear block (gated on `if (consultationId)`)
   to also remove tibokRole, tibokNurseId, tibokNurseInfo,
   tibokConsultationMode, tibokPresentialActor, and tibokHandoffState.
   Without this, a stale tibokRole='nurse' from a previous consult
   would leak into a new doctor-only consult and trigger nurse gating.

2) After the simulation block (and outside the clear gate so it runs on
   every hub mount), read role / nurseId / nurseData / consultationMode
   / presentialActor from URL and setItem to sessionStorage:
   - role: validated as 'doctor' | 'nurse' before write.
   - nurseId: plain string passthrough.
   - nurseData: same decode-retry pattern the hub already uses for doctorData (decodeURIComponent up to 5×, trim trailing junk after the last '}', JSON.parse). On success, JSON-stringify the parsed blob and store; on failure, warn and skip.
   - consultationMode + presentialActor: plain string passthrough.

Why duplicate with hooks/use-tibok-patient-data.ts (Phase 2.D.A): that hook runs on the workflow page, after the navigation. The hub is the TIBOK landing page, before the navigation. Both writers need to fire because either entry point can be used (hub for fresh TIBOK, direct / for existing TIBOK URLs that bypass the hub). The keys are write-only-when-present, so the duplicates idempotently set the same value to sessionStorage.

Backward-compat:
- Telemedicine/legacy URLs without role/nurseId/etc.: nothing is setItem'd. The clear block still runs on fresh consults, ensuring no stale nurse-led state leaks. Doctor sees all 5 steps as before.
- The 4 payload sites (Phase 1 + 2.D.A) already cascade sessionStorage > URL > default, so they pick up these values automatically once written here.
- useTibokBridge() initial state already reads sessionStorage, so the React-side gating in app/page.tsx and components/questions-form.tsx (Phase 2.D.B) reflects the persisted role on first render.

No fallback needed in hooks/use-tibok-patient-data.ts: useTibokBridge already reads sessionStorage as initial state, the saveTibokDraft helper reads sessionStorage directly, and the 4 payload sites cascade through sessionStorage. Once the hub persists, every downstream consumer sees the value.

Type-check clean. No DB migration. No TIBOK changes.