### PR TITLE
Phase 2.D.B.2: wire saveTibokDraft to read consultationId from hub-se…

### DIFF
--- a/app/consultation-hub/page.tsx
+++ b/app/consultation-hub/page.tsx
@@ -69,6 +69,10 @@ export default function ConsultationHubPage() {
         sessionStorage.removeItem('tibokNurseId')
         sessionStorage.removeItem('tibokNurseInfo')
         sessionStorage.removeItem('tibokHandoffState')
+        // Phase 2.D.B.2: clear the consultationId we cache here so a stale
+        // one from an earlier consult never wins the lookup cascade in
+        // lib/tibok-draft-service.ts.
+        sessionStorage.removeItem('tibokConsultationId')
       }
 
       // SIMULATION MODE: Store flag and use consultationType from URL directly
@@ -88,6 +92,15 @@ export default function ConsultationHubPage() {
       // running on / finds nothing in URL params and never sets sessionStorage.
       // Persisting here, before the navigation, is the only way these params
       // survive the hub → workflow transition.
+      // Phase 2.D.B.2 — the hub is the only point on AI-DOCTOR where the
+      // consultationId is reliably present in the URL (the workflow page on
+      // / is reached via a query-stripping router.push). Persist here so
+      // saveTibokDraft can find it on every step submit downstream.
+      if (consultationId) {
+        sessionStorage.setItem('tibokConsultationId', consultationId)
+        console.log('🆔 [Hub] TIBOK consultation ID:', consultationId)
+      }
+
       const roleParam = urlParams.get('role')
       if (roleParam === 'doctor' || roleParam === 'nurse') {
         sessionStorage.setItem('tibokRole', roleParam)

--- a/lib/tibok-draft-service.ts
+++ b/lib/tibok-draft-service.ts
@@ -15,6 +15,8 @@
  * consultation_records, so repeat calls on the same step are safe.
  */
 
+import { consultationDataService } from '@/lib/consultation-data-service'
+
 const FETCH_TIMEOUT_MS = 5000
 const RETRY_DELAY_MS = 1000
 
@@ -59,17 +61,45 @@ function resolveTibokUrl(): string {
   return 'https://tibok.mu'
 }
 
+/**
+ * Phase 2.D.B.2 — 4-source cascade. Order matters: more authoritative /
+ * fresher sources first.
+ *
+ *   1. URL ?consultationId=… — only present when AI-DOCTOR is still on a
+ *      page that received it directly from TIBOK (the hub). After
+ *      router.push('/'), the URL is bare so this misses on workflow pages.
+ *   2. sessionStorage.tibokConsultationId — written by app/consultation-hub/
+ *      page.tsx in Phase 2.D.B.2. Survives the hub → / navigation.
+ *   3. consultationDataService.getCurrentConsultationId() — set by
+ *      app/page.tsx:292 from the loaded patient data. Note: this method
+ *      auto-generates a fake `consultation_<ts>_<rand>` if none cached, so
+ *      it should never return null in practice, but if the page hasn't
+ *      mounted yet it can return a generated id that doesn't match the
+ *      TIBOK UUID. (1) and (2) above protect against that.
+ *   4. sessionStorage.consultationPatientData.consultationId — legacy cache
+ *      written by HubWorkflowSelector for the normal-consultation path.
+ *      Kept as a defensive last resort.
+ */
 function getConsultationId(): string | null {
   if (typeof window === 'undefined') return null
-  // Prefer URL (always authoritative for the current consultation), then
-  // sessionStorage caches.
+
   try {
     const fromUrl = new URLSearchParams(window.location.search).get('consultationId')
     if (fromUrl) return fromUrl
   } catch {
-    // ignore
+    // ignore — fall through
   }
-  // Common cache locations seen in the codebase
+
+  const fromTibokSession = sessionStorage.getItem('tibokConsultationId')
+  if (fromTibokSession) return fromTibokSession
+
+  try {
+    const fromService = consultationDataService.getCurrentConsultationId()
+    if (fromService) return fromService
+  } catch {
+    // ignore — fall through
+  }
+
   const stored = sessionStorage.getItem('consultationPatientData')
   if (stored) {
     try {
@@ -79,6 +109,7 @@ function getConsultationId(): string | null {
       // ignore
     }
   }
+
   return null
 }
 
@@ -139,7 +170,10 @@ export async function saveTibokDraft(step: DraftStep, payload: unknown): Promise
 
   const consultationId = getConsultationId()
   if (!consultationId) {
-    console.warn('💾 [TIBOK draft] skipping save — no consultationId available for step:', step)
+    console.warn(
+      `💾 [TIBOK draft] skipping save — no consultationId available for step: ${step}. ` +
+        'Sources checked: URL, tibokConsultationId, consultationDataService, consultationPatientData. All null.'
+    )
     return { success: false, error: 'no_consultation_id' }
   }
 


### PR DESCRIPTION
…t sessionStorage + service singleton fallback

Bug observed in staging consult 73f8d0f8: saveTibokDraft passed the role==='nurse' gate (sessionStorage written by the hub at 2.D.B.1) but its getConsultationId() cascade returned null on every step submit, so patient/clinical/questions never reached TIBOK and consultation_records stayed empty. The doctor side then saw the green handoff banner without any draft to load.

Root cause: saveTibokDraft's cascade was URL → consultationPatientData only. On the workflow page (/) the URL is bare (HubWorkflowSelector calls router.push without query preservation, cf. Phase 2.D.B.1), and consultationPatientData is only written for the legacy normal-flow prefill — not always present.

Fix in 2 files:

app/consultation-hub/page.tsx
- New write: when the URL carries consultationId, sessionStorage.setItem ('tibokConsultationId', consultationId) — mirrors the role/nurseId/ nurseInfo writes added at 2.D.B.1 so the value survives the hub → / navigation.
- Extended the fresh-consult clear block (gated on `if (consultationId)`) with sessionStorage.removeItem('tibokConsultationId') for symmetry, so a stale id from an earlier consult cannot win the cascade lookup.

lib/tibok-draft-service.ts
- Static `import { consultationDataService } from '@/lib/consultation- data-service'` at module top. No cycle: consultation-data-service has zero imports, verified by grep.
- Rewrote getConsultationId() with a 4-source cascade, most authoritative first:
    1. URL ?consultationId — wins on the hub itself
    2. sessionStorage.tibokConsultationId — wins after navigation
    3. consultationDataService.getCurrentConsultationId() — set from app/page.tsx:292 when patientData carries it; documented caveat that this method auto-generates a fake id when nothing is cached, so sources 1+2 are the real safeguards against fake-id leaks
    4. sessionStorage.consultationPatientData.consultationId — legacy cache, kept as defensive last resort
- Updated the skip-save log to enumerate the sources checked, so the staging console makes the cascade transparent.

Backward-compat:
- Telemedicine / doctor-only / chronic / dermatology: saveTibokDraft is still gated on role==='nurse' before any of this runs. Those paths still no-op as before. The cascade only matters when a nurse is actually trying to push a draft.
- The hub clear block now wipes tibokConsultationId on every fresh consult, so cross-consult bleed of the cached id is impossible.

Type-check clean. No DB migration. No TIBOK changes.