### PR TITLE
fix(drafts): resolve tibokUrl dynamically (URL → sessionStorage → ref…

### DIFF
--- a/app/consultation-hub/page.tsx
+++ b/app/consultation-hub/page.tsx
@@ -73,6 +73,9 @@ export default function ConsultationHubPage() {
         // one from an earlier consult never wins the lookup cascade in
         // lib/tibok-draft-service.ts.
         sessionStorage.removeItem('tibokConsultationId')
+        // Phase 2.D.B.4: clear the cached tibokUrl so a stale preview origin
+        // from an earlier consult cannot win against a new one.
+        sessionStorage.removeItem('tibokUrl')
       }
 
       // SIMULATION MODE: Store flag and use consultationType from URL directly
@@ -99,6 +102,17 @@ export default function ConsultationHubPage() {
       if (consultationId) {
         sessionStorage.setItem('tibokConsultationId', consultationId)
         console.log('🆔 [Hub] TIBOK consultation ID:', consultationId)
+      }
+
+      // Phase 2.D.B.4 — TIBOK now propagates the origin it was served from
+      // via ?tibokUrl=… so AI-DOCTOR can POST drafts back to the same
+      // origin (prod, preview, or localhost). Persist for the same reason
+      // as tibokConsultationId: the URL is bare on the workflow page after
+      // the hub → / navigation strips query params.
+      const tibokUrlParam = urlParams.get('tibokUrl')
+      if (tibokUrlParam) {
+        sessionStorage.setItem('tibokUrl', tibokUrlParam)
+        console.log('🌐 [Hub] TIBOK URL:', tibokUrlParam)
       }
 
       const roleParam = urlParams.get('role')

--- a/lib/tibok-draft-service.ts
+++ b/lib/tibok-draft-service.ts
@@ -25,39 +25,52 @@ type DraftStep = 'patient' | 'clinical' | 'questions'
 type SaveResult = { success: true } | { success: false; error: string }
 
 /**
- * Resolve the TIBOK base URL the same way the report components do
- * (professional-report.tsx:3818-3840 etc.):
- *   1. ?tibokUrl=... param (highest priority, set explicitly by caller)
- *   2. document.referrer if its hostname is on the TIBOK whitelist
- *   3. hardcoded https://tibok.mu fallback
+ * Resolve the TIBOK base URL with a 4-source cascade so AI-DOCTOR POSTs
+ * drafts back to the same origin TIBOK was served from (prod, Vercel
+ * preview, or localhost dev).
  *
- * Inlined here to keep this module self-contained — the report components
- * each have their own copy and we don't want to refactor a shared helper
- * out of MVP scope.
+ *   1. URL ?tibokUrl=… — wins on the hub itself, where TIBOK 2.D.B.3
+ *      injects this param when launching the iframe.
+ *   2. sessionStorage.tibokUrl — written by app/consultation-hub/page.tsx
+ *      at 2.D.B.4. Survives the hub → / navigation that strips query params.
+ *   3. document.referrer origin — last-resort heuristic, only trusted
+ *      when the hostname mentions "tibok" (case-insensitive). Defends
+ *      against an arbitrary embedder hijacking the draft target.
+ *   4. https://tibok.mu — production fallback when nothing else applies.
+ *
+ * Returns the resolved origin (no trailing slash) so callers can append
+ * "/api/…" directly.
  */
 function resolveTibokUrl(): string {
   if (typeof window === 'undefined') return 'https://tibok.mu'
 
+  // 1) URL param — explicit wins.
   try {
-    const params = new URLSearchParams(window.location.search)
-    const param = params.get('tibokUrl')
-    if (param) return decodeURIComponent(param)
+    const fromUrl = new URLSearchParams(window.location.search).get('tibokUrl')
+    if (fromUrl) return decodeURIComponent(fromUrl)
   } catch {
-    // ignore — fall through to referrer
+    // ignore — fall through
   }
 
-  if (typeof document !== 'undefined' && document.referrer) {
-    try {
-      const referrer = new URL(document.referrer)
-      const allowed = ['tibok.mu', 'v0-tibokmain2.vercel.app', 'localhost']
-      if (allowed.some(domain => referrer.hostname.includes(domain))) {
-        return referrer.origin
-      }
-    } catch {
-      // ignore — fall through to default
+  // 2) sessionStorage cache (set by the hub).
+  try {
+    const fromSession = sessionStorage.getItem('tibokUrl')
+    if (fromSession) return fromSession
+  } catch {
+    // ignore — fall through
+  }
+
+  // 3) Referrer origin, but only if it looks like TIBOK.
+  try {
+    if (typeof document !== 'undefined' && document.referrer) {
+      const referrerOrigin = new URL(document.referrer).origin
+      if (/tibok/i.test(referrerOrigin)) return referrerOrigin
     }
+  } catch {
+    // ignore — fall through
   }
 
+  // 4) Production fallback.
   return 'https://tibok.mu'
 }
 
@@ -182,6 +195,7 @@ export async function saveTibokDraft(step: DraftStep, payload: unknown): Promise
   const body = JSON.stringify({ consultationId, step, payload })
 
   console.log(`💾 Saving draft step=${step} to TIBOK`)
+  console.log('🌐 [TIBOK draft] base URL resolved:', tibokUrl)
 
   // First attempt
   let result = await postOnce(url, body)


### PR DESCRIPTION
…errer → fallback)

TIBOK 2.D.B.3 (commit c658911) ships CORS allowlists on the draft endpoints + propagates a new ?tibokUrl URL param so AI-DOCTOR posts drafts back to whichever origin TIBOK was served from (prod, Vercel preview, localhost). Until now lib/tibok-draft-service.ts ignored that and hardcoded https://tibok.mu past the referrer fallback, so drafts from a TIBOK preview targeted prod and were blocked by CORS.

app/consultation-hub/page.tsx
- Add sessionStorage.removeItem('tibokUrl') to the existing fresh-consult clear block (paired with tibokConsultationId, tibokRole, tibokNurseId etc.) so a stale preview origin from an earlier consult cannot win the lookup against a fresh one.
- After the tibokConsultationId setItem, persist the new ?tibokUrl param to sessionStorage with a 🌐 [Hub] log. Same survival reason as 2.D.B.2: HubWorkflowSelector calls router.push('/') without query preservation, so the workflow page sees a bare URL and needs sessionStorage.

lib/tibok-draft-service.ts
- Rewrite resolveTibokUrl() with a 4-source cascade, most authoritative first:
    1. URL ?tibokUrl — wins on the hub itself.
    2. sessionStorage.tibokUrl — wins after navigation, written by the hub at this same commit.
    3. document.referrer origin, but only when the hostname matches /tibok/i — defends against an arbitrary embedder hijacking the draft target. Replaces the previous static allowlist that missed nurse-led preview branches.
    4. https://tibok.mu — production fallback.
- Returns the resolved origin (no trailing slash) so callers append "/api/…" directly.
- Add a 🌐 [TIBOK draft] base URL resolved log right before the fetch so staging traces show which origin AI-DOCTOR is targeting.

Backward-compat:
- Telemedicine/legacy URLs without ?tibokUrl: cascade falls through to the referrer (still recognises tibok.mu) and finally https://tibok.mu — same effective behaviour as before.
- saveTibokDraft still self-gates on role==='nurse' and ignores failures silently, so a misconfigured target only causes a CORS warning, never a blocked nurse.
- The bridge hook (use-tibok-bridge.ts) is unrelated and untouched — postMessage origin allowlist there still treats tibokUrl separately.

Type-check clean. No DB migration. No TIBOK changes (TIBOK already shipped its half at c658911).