### PR TITLE
feat(handoff): hydrate doctor with nurse drafts and jump to Diagnosis…

### DIFF
--- a/app/consultation-hub/page.tsx
+++ b/app/consultation-hub/page.tsx
@@ -11,6 +11,7 @@ import { HubWorkflowSelector } from '@/components/consultation-hub/hub-workflow-
 import { HistoryList, ConsultationDetailModal } from '@/lib/follow-up/shared'
 import type { ConsultationHistoryItem } from '@/lib/follow-up/shared'
 import { fetchTibokConsultationData } from '@/lib/tibok-consultation-service'
+import { loadTibokDraft } from '@/lib/tibok-draft-service'
 
 type WorkflowStep = 'search' | 'summary' | 'workflow'
 
@@ -173,6 +174,59 @@ export default function ConsultationHubPage() {
       if (presentialActorParam) {
         sessionStorage.setItem('tibokPresentialActor', presentialActorParam)
         console.log('👤 [Hub] TIBOK presential actor:', presentialActorParam)
+      }
+
+      // Phase 2.D.C — doctor handoff prefetch.
+      //
+      // When the doctor lands on the hub for a nurse-led consultation that
+      // already has drafts (handoff_state='awaiting_doctor'), pull the 3
+      // datasets the nurse persisted at consultation_records and stage them
+      // in sessionStorage. The user-driven navigation (Continuer →) then
+      // triggers app/page.tsx mount, which reads tibokHandoffPayload,
+      // hydrates consultationDataService, and jumps to the Diagnosis step.
+      //
+      // Strict gates so we never disturb other flows:
+      //   - role === 'doctor' (nurse-side never auto-loads — would race with /save)
+      //   - consultationId present (nothing to fetch otherwise)
+      //   - tibokHandoffHydrated !== consultationId (idempotent on refresh)
+      //
+      // Failure mode: silent. If /load returns null or any of the 3 datasets
+      // is missing, we don't stage anything and the doctor lands on step 0.
+      if (roleParam === 'doctor' && consultationId) {
+        const alreadyHydrated = sessionStorage.getItem('tibokHandoffHydrated')
+        if (alreadyHydrated === consultationId) {
+          console.log('🩺 [Hub] Already hydrated this consultation, skip re-fetch')
+        } else {
+          console.log('🩺 [Hub] Doctor handoff detected — fetching nurse drafts...')
+          try {
+            const drafts = await loadTibokDraft(consultationId)
+            const isComplete = !!(
+              drafts &&
+              drafts.patientData &&
+              drafts.clinicalData &&
+              drafts.questionsData
+            )
+            if (isComplete && drafts) {
+              sessionStorage.setItem(
+                'tibokHandoffPayload',
+                JSON.stringify({
+                  consultationId,
+                  patientData: drafts.patientData,
+                  clinicalData: drafts.clinicalData,
+                  questionsData: drafts.questionsData,
+                  targetStep: 'diagnosis',
+                  workflowStep: drafts.workflowStep,
+                })
+              )
+              sessionStorage.setItem('tibokHandoffHydrated', consultationId)
+              console.log('🩺 [Hub] Drafts staged for hydration, jumping to Diagnosis')
+            } else {
+              console.log('🩺 [Hub] Drafts not ready or incomplete, doctor starts at step 0')
+            }
+          } catch (err) {
+            console.warn('🩺 [Hub] Handoff prefetch failed, doctor starts at step 0:', err)
+          }
+        }
       }
 
       // Extract and save doctor data from URL params

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -137,6 +137,47 @@ export default function MedicalAIExpert() {
         console.log('🧹 Clearing old consultation data for fresh start...')
         await consultationDataService.clearCurrentConsultation()
 
+        // Phase 2.D.C — doctor handoff hydration.
+        // The hub staged a tibokHandoffPayload in sessionStorage when it
+        // detected role=doctor + handoff_state=awaiting_doctor. Sequence
+        // matters: we run AFTER the localStorage clear above so we rebuild
+        // a clean state, and BEFORE setCheckingReturningPatient(false) so
+        // the L325 loadSavedData useEffect picks up our writes on the
+        // next render. Single-shot: the payload is removed after use.
+        try {
+          const handoffRaw = sessionStorage.getItem('tibokHandoffPayload')
+          if (handoffRaw) {
+            const payload = JSON.parse(handoffRaw)
+            if (payload?.consultationId) {
+              console.log('🩺 [Page] Hydrating from nurse handoff:', payload.consultationId)
+              consultationDataService.setCurrentConsultationId(payload.consultationId)
+              if (payload.patientData) {
+                await consultationDataService.saveStepData(0, payload.patientData)
+              }
+              if (payload.clinicalData) {
+                await consultationDataService.saveStepData(1, payload.clinicalData)
+              }
+              if (payload.questionsData) {
+                await consultationDataService.saveStepData(2, payload.questionsData)
+              }
+              // Map semantic targetStep → live steps array index. The 5-step
+              // workflow has Diagnosis at id=3; if the array ever changes
+              // (e.g. workflow split), this lookup keeps the jump correct.
+              const targetIndex = steps.findIndex(s =>
+                s.title?.toLowerCase().includes(String(payload.targetStep || 'diagnosis').toLowerCase())
+              )
+              const safeIndex = targetIndex >= 0 ? targetIndex : 3
+              setCurrentStep(safeIndex)
+              console.log('🩺 [Page] Jumped to step index', safeIndex, '(', payload.targetStep, ')')
+            }
+            // Single-shot: clear regardless so a refresh doesn't re-hydrate.
+            sessionStorage.removeItem('tibokHandoffPayload')
+          }
+        } catch (err) {
+          console.warn('⚠️ [Page] Failed to hydrate handoff payload:', err)
+          sessionStorage.removeItem('tibokHandoffPayload')
+        }
+
         setCheckingReturningPatient(false)
         return
       }

--- a/lib/tibok-draft-service.ts
+++ b/lib/tibok-draft-service.ts
@@ -213,3 +213,96 @@ export async function saveTibokDraft(step: DraftStep, payload: unknown): Promise
   console.log(`✅ TIBOK draft saved (step=${step})`)
   return { success: true }
 }
+
+// ============================================================================
+// Phase 2.D.C — load drafts on doctor handoff
+// ============================================================================
+
+/**
+ * Drafts the doctor needs at the handoff boundary. All four fields are
+ * optional from the wire; the hub is responsible for deciding whether the
+ * payload is "complete enough" to hydrate (it requires patient + clinical
+ * + questions all present).
+ */
+export interface TibokDraftPayload {
+  patientData: any | null
+  clinicalData: any | null
+  questionsData: any | null
+  workflowStep: number | null
+}
+
+/**
+ * Fetch the nurse drafts that TIBOK persisted at consultation_records for
+ * a given consultation. Returns null on any failure (network, non-OK
+ * status, unknown response shape) — callers must treat this as best-effort
+ * enrichment and fall back to the standard step-0 entry.
+ *
+ * Tolerant of three plausible response shapes (TIBOK's exact contract is
+ * not auditable from this sandbox at the moment):
+ *   - { ok: true, data: { patient_data, clinical_data, questions_data, workflow_step } }
+ *   - { patientData, clinicalData, questionsData, workflowStep }
+ *   - { success: true, draft: { … } }
+ * Anything else maps to null and the doctor starts at step 0 — documented
+ * graceful-degrade behaviour per the Phase 2.D.C garde-fous.
+ */
+export async function loadTibokDraft(
+  consultationId: string
+): Promise<TibokDraftPayload | null> {
+  if (typeof window === 'undefined') return null
+  if (!consultationId) return null
+
+  const baseUrl = resolveTibokUrl()
+  const url = `${baseUrl}/api/consultation/draft/load?consultationId=${encodeURIComponent(consultationId)}`
+  console.log('📥 [TIBOK draft] loading from:', url)
+
+  let json: any
+  try {
+    const controller = new AbortController()
+    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
+    const res = await fetch(url, {
+      method: 'GET',
+      signal: controller.signal,
+      cache: 'no-store',
+    })
+    clearTimeout(timeoutId)
+    if (!res.ok) {
+      console.warn(`⚠️ [TIBOK draft] load returned HTTP ${res.status}`)
+      return null
+    }
+    json = await res.json()
+  } catch (err: any) {
+    console.warn('⚠️ [TIBOK draft] load failed:', err?.name === 'AbortError' ? 'timeout' : (err?.message || err))
+    return null
+  }
+
+  // Find the inner record across the three accepted shapes.
+  const record =
+    (json && typeof json === 'object' && (json.data ?? json.draft ?? json)) || null
+  if (!record || typeof record !== 'object') {
+    console.warn('⚠️ [TIBOK draft] load: response did not match any known shape:', Object.keys(json || {}))
+    return null
+  }
+
+  // Accept either snake_case (from DB columns) or camelCase (from a route
+  // that already mapped them). Falsy → null so downstream completeness
+  // checks are unambiguous.
+  const patientData = record.patientData ?? record.patient_data ?? null
+  const clinicalData = record.clinicalData ?? record.clinical_data ?? null
+  const questionsData = record.questionsData ?? record.questions_data ?? null
+  const workflowStepRaw = record.workflowStep ?? record.workflow_step ?? null
+  const workflowStep =
+    typeof workflowStepRaw === 'number'
+      ? workflowStepRaw
+      : (typeof workflowStepRaw === 'string' && /^\d+$/.test(workflowStepRaw))
+        ? parseInt(workflowStepRaw, 10)
+        : null
+
+  console.log('✅ [TIBOK draft] loaded', {
+    hasPatient: !!patientData,
+    hasClinical: !!clinicalData,
+    hasQuestions: !!questionsData,
+    workflowStep,
+  })
+
+  return { patientData, clinicalData, questionsData, workflowStep }
+}


### PR DESCRIPTION
… (Phase 2.D.C)

When a doctor lands on a nurse-led consultation in handoff state, AI-DOCTOR now (1) prefetches the 3 drafts the nurse persisted at consultation_records, (2) hydrates consultationDataService with them, and (3) jumps directly to the Diagnosis step (index 3) instead of starting from Patient Info.

lib/tibok-draft-service.ts
- New TibokDraftPayload interface and loadTibokDraft(consultationId).
- Fetch GET ${tibokUrl}/api/consultation/draft/load?consultationId=… using the same resolveTibokUrl cascade saveTibokDraft uses (Phase 2.D.B.4).
- 5 s AbortController timeout + cache: 'no-store'.
- Tolerant response normaliser: accepts the three plausible shapes for the TIBOK route (the exact contract is not auditable from this sandbox, so the helper handles them all and returns null on anything else):
    1. { ok: true, data: { patient_data, clinical_data, questions_data, workflow_step } }
    2. { patientData, clinicalData, questionsData, workflowStep }
    3. { success: true, draft: { … } } Both snake_case and camelCase keys are accepted at the inner level.
- Returns null on non-OK status, network error, timeout, or unknown shape. Callers must treat success as best-effort.

app/consultation-hub/page.tsx
- Static import of loadTibokDraft.
- New prefetch block placed inside the existing init useEffect, right after the role/nurseId/nurseInfo writes and before the doctor-data parsing. Strict gates per the brief:
    - roleParam === 'doctor' (nurse-side never auto-loads — would race against the in-flight /save calls she's making at the same time).
    - consultationId must be present (nothing to fetch otherwise).
    - sessionStorage.tibokHandoffHydrated !== consultationId (idempotent on refresh — second mount does not re-fetch).
- On a complete payload (all 3 datasets present), stores tibokHandoffPayload + tibokHandoffHydrated in sessionStorage. On a partial payload (e.g. doctor opened the tab before nurse finished), stages nothing — doctor lands on step 0 as before.
- Failures are silent: warn-log only.

app/page.tsx
- Inside the existing checkReturningPatient async useEffect, immediately after the await consultationDataService.clearCurrentConsultation() call. Ordering matters: clear happens first so we rebuild a clean state, hydrate next so the L325 loadSavedData effect picks up the writes on the next render.
- Reads sessionStorage.tibokHandoffPayload, calls consultationDataService.setCurrentConsultationId() + saveStepData(0/1/2) in sequence — same writers the form components use, so the rest of the flow stays consistent.
- Computes the Diagnosis index dynamically via steps.findIndex with a case-insensitive title match; falls back to hard-coded 3 if the lookup fails (defends against future workflow restructuring).
- Single-shot: tibokHandoffPayload is removed after use, so a manual refresh of / does not re-hydrate. The hub-side tibokHandoffHydrated=consultationId guard prevents the second /load fetch on a hub remount.

Garde-fous verified:
- role !== 'doctor' (nurse / null / unknown): the hub block is gated, no /load fetch fires, no payload is staged. Nurse continues to /save unaffected.
- No tibokConsultationId: hub block exits, app/page.tsx hydrate block finds nothing in sessionStorage, doctor starts at step 0.
- /load returns null or partial: hub does not stage anything, doctor starts at step 0 with the standard hub → / flow.
- Refresh of the workflow page: hub guard blocks /load re-fetch (tibokHandoffHydrated == consultationId), and tibokHandoffPayload was already cleared after first use.
- saveTibokDraft cascade: untouched.
- TIBOK routes: untouched.

Type-check clean. Three files modified, no new dependencies, no DB migration.