### PR TITLE
fix(tibok-handoff): use persisted tibokUrl from sessionStorage when sending documents

### DIFF
--- a/components/chronic-disease/chronic-professional-report.tsx
+++ b/components/chronic-disease/chronic-professional-report.tsx
@@ -3001,6 +3001,24 @@ export default function ChronicProfessionalReport({
           return decodeURIComponent(urlParam)
         }
 
+        // Phase 2.D.B.4: the hub persists the originating Tibok origin to
+        // sessionStorage BEFORE the query-stripping router.push to the
+        // workflow page. By the time we POST documents the URL param is
+        // gone, so this sessionStorage value is the only reliable way to
+        // hit the SAME Tibok deployment that launched the consult (prod,
+        // branch preview, or localhost). Without this we fell back to the
+        // hardcoded prod alias, which redirects on the CORS preflight →
+        // "Failed to fetch" and documents never reach the patient.
+        try {
+          const storedTibokUrl = sessionStorage.getItem('tibokUrl')
+          if (storedTibokUrl) {
+            console.log('📍 Using Tibok URL from sessionStorage:', storedTibokUrl)
+            return storedTibokUrl
+          }
+        } catch {
+          // sessionStorage unavailable — fall through
+        }
+
         // Check referrer
         if (document.referrer) {
           try {

--- a/components/dermatology/dermatology-professional-report.tsx
+++ b/components/dermatology/dermatology-professional-report.tsx
@@ -3675,6 +3675,23 @@ isEmergency: isEmergencyCase
  return decodeURIComponent(urlParam)
  }
 
+ // Phase 2.D.B.4: the hub persists the originating Tibok origin to
+ // sessionStorage BEFORE the query-stripping router.push to /dermatology.
+ // By the time we POST documents the URL param is gone, so this is the
+ // only reliable way to hit the SAME Tibok deployment that launched the
+ // consult (prod, branch preview, or localhost). Without it we fell back
+ // to the hardcoded prod alias, which redirects on the CORS preflight →
+ // "Failed to fetch" and documents never reach the patient.
+ try {
+ const storedTibokUrl = sessionStorage.getItem('tibokUrl')
+ if (storedTibokUrl) {
+ console.log('📍 Using Tibok URL from sessionStorage:', storedTibokUrl)
+ return storedTibokUrl
+ }
+ } catch {
+ // sessionStorage unavailable — fall through
+ }
+
  // Check referrer
  if (document.referrer) {
  try {

--- a/components/professional-report.tsx
+++ b/components/professional-report.tsx
@@ -3819,6 +3819,23 @@ const handleSendDocuments = async () => {
  return decodeURIComponent(urlParam)
  }
 
+ // Phase 2.D.B.4: the hub persists the originating Tibok origin to
+ // sessionStorage BEFORE the query-stripping router.push to the workflow
+ // page. By the time we POST documents the URL param is gone, so this is
+ // the only reliable way to hit the SAME Tibok deployment that launched
+ // the consult (prod, branch preview, or localhost). Without it we fell
+ // back to the hardcoded default, which can redirect on the CORS
+ // preflight → "Failed to fetch" and documents never reach the patient.
+ try {
+ const storedTibokUrl = sessionStorage.getItem('tibokUrl')
+ if (storedTibokUrl) {
+ console.log('📍 Using Tibok URL from sessionStorage:', storedTibokUrl)
+ return storedTibokUrl
+ }
+ } catch {
+ // sessionStorage unavailable — fall through
+ }
+
  if (document.referrer) {
  try {
  const referrerUrl = new URL(document.referrer)


### PR DESCRIPTION
## Problème

"Finalize and send" échoue silencieusement (testé sur dermato, identique sur general + chronic) : les documents sont POSTés vers l'alias prod hardcodé `https://v0-tibokmain2.vercel.app`, dont le preflight CORS renvoie une redirection (`Redirect is not allowed for a preflight request` → `Failed to fetch`). Rien n'arrive au patient.

## Cause racine

`getTibokUrl()` ne lisait que le param URL `?tibokUrl=`, strippé par la navigation hub → workflow (`router.push`), puis tombait sur un alias prod hardcodé. La consult était lancée depuis un preview de branche Tibok. Le hub persiste pourtant déjà l'origine réelle dans `sessionStorage['tibokUrl']` (Phase 2.D.B.4) — les 3 composants rapport ne le lisaient juste jamais.

## Fix

Lecture `sessionStorage.getItem('tibokUrl')` en priorité (après le param URL, avant referrer/fallback) dans `professional-report.tsx`, `dermatology-professional-report.tsx`, `chronic-professional-report.tsx`. L'envoi cible désormais le même déploiement Tibok qui a lancé la consult.

## Test

- [ ] Relancer une consult dermato depuis Tibok → "Finalize and send" → vérifier réception côté patient
- [ ] Idem general + chronic

https://claude.ai/code/session_01PCkJ3ktUpfmSziunR8rauM

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCkJ3ktUpfmSziunR8rauM)_