### PR TITLE
fix(report): regenerate when a stale/empty draft row blocks the report

### DIFF
--- a/components/dermatology/dermatology-professional-report.tsx
+++ b/components/dermatology/dermatology-professional-report.tsx
@@ -1935,10 +1935,27 @@ useEffect(() => {
  const result = await response.json()
  
  if (result.success && result.data) {
+ // A draft row can exist with an empty / partial report_content — this
+ // happens when an earlier run on the SAME consultationId saved a draft
+ // before the report finished (e.g. the CORS send failures during
+ // testing). Blindly trusting result.data here set report=<empty> and
+ // shouldGenerateReport=false → a completely blank report with no way
+ // to regenerate. Only treat the draft as usable when it actually has
+ // narrative content; otherwise fall through to generation.
+ const draftReport: any = result.data.report_content
+ const draftRapport = draftReport?.compteRendu?.rapport
+ const hasUsableDraft =
+ !!draftRapport &&
+ typeof draftRapport === 'object' &&
+ Object.values(draftRapport).some(
+ (v) => typeof v === 'string' && v.trim().length > 0
+ )
+
+ if (hasUsableDraft) {
  console.log('📂 Loading draft from database')
- 
- setReport(result.data.report_content)
- 
+
+ setReport(draftReport)
+
  // Only update doctor info if it exists in the draft
  if (result.data.doctor_info) {
  setDoctorInfo(prev => ({
@@ -1950,27 +1967,38 @@ useEffect(() => {
  adresseCabinet: result.data.doctor_info.adresseCabinet || prev.adresseCabinet,
  }))
  }
- 
+
  setModifiedSections(new Set(result.data.modified_sections || []))
         // Always reset to draft on page load/refresh to allow re-validation for testing
         setValidationStatus('draft')
- 
+
  toast({
  title: "Draft loaded",
  description: "Your previous edits have been restored (ready for re-validation)",
  duration: 3000
  })
- 
+
  setShouldGenerateReport(false)
  } else {
- console.log('No draft found, will generate new report if patient data is valid')
- 
- const hasValidPatientData = patientData && 
+ console.log('⚠️ Draft row exists but report_content is empty/incomplete — regenerating instead of showing a blank report')
+
+ const hasValidPatientData = patientData &&
  patientData.name !== 'Patient' &&
  patientData.name !== 'Non spécifié' &&
  patientData.name !== '1 janvier 1970' &&
  !patientData.name?.includes('1970')
- 
+
+ setShouldGenerateReport(hasValidPatientData)
+ }
+ } else {
+ console.log('No draft found, will generate new report if patient data is valid')
+
+ const hasValidPatientData = patientData &&
+ patientData.name !== 'Patient' &&
+ patientData.name !== 'Non spécifié' &&
+ patientData.name !== '1 janvier 1970' &&
+ !patientData.name?.includes('1970')
+
  setShouldGenerateReport(hasValidPatientData)
  }
  } catch (error) {

--- a/components/professional-report.tsx
+++ b/components/professional-report.tsx
@@ -1981,34 +1981,59 @@ useEffect(() => {
  const result = await response.json()
  
  if (result.success && result.data) {
+ // Guard against empty/partial draft rows saved by an earlier run on
+ // the SAME consultationId (e.g. interrupted/failed send). Loading an
+ // empty report_content here blanked the report AND blocked
+ // regeneration. Only use the draft when it has real narrative content.
+ const draftReport: any = result.data.report_content
+ const draftRapport = draftReport?.compteRendu?.rapport
+ const hasUsableDraft =
+ !!draftRapport &&
+ typeof draftRapport === 'object' &&
+ Object.values(draftRapport).some(
+ (v) => typeof v === 'string' && v.trim().length > 0
+ )
+
+ if (hasUsableDraft) {
  console.log('📂 Loading draft from database')
- 
- setReport(result.data.report_content)
- 
+
+ setReport(draftReport)
+
  // Only update doctor info if it exists in the draft
  if (result.data.doctor_info) {
  setDoctorInfo(result.data.doctor_info)
  }
- 
+
  setModifiedSections(new Set(result.data.modified_sections || []))
  setValidationStatus(result.data.validation_status || 'draft')
- 
+
  toast({
  title: "Draft loaded",
  description: "Your previous edits have been restored",
  duration: 3000
  })
- 
+
  setShouldGenerateReport(false)
  } else {
- console.log('No draft found, will generate new report if patient data is valid')
- 
- const hasValidPatientData = patientData && 
+ console.log('⚠️ Draft row exists but report_content is empty/incomplete — regenerating instead of showing a blank report')
+
+ const hasValidPatientData = patientData &&
  patientData.name !== 'Patient' &&
  patientData.name !== 'Non spécifié' &&
  patientData.name !== '1 janvier 1970' &&
  !patientData.name?.includes('1970')
- 
+
+ setShouldGenerateReport(hasValidPatientData)
+ }
+ } else {
+ console.log('No draft found, will generate new report if patient data is valid')
+
+ const hasValidPatientData = patientData &&
+ patientData.name !== 'Patient' &&
+ patientData.name !== 'Non spécifié' &&
+ patientData.name !== '1 janvier 1970' &&
+ !patientData.name?.includes('1970')
+
  setShouldGenerateReport(hasValidPatientData)
  }
  } catch (error) {


### PR DESCRIPTION
## Symptôme

Rapport dermato complètement vide ("il n'y a rien dans le rapport") alors que le diagnostic + médicaments + investigations sont bien générés.

## Cause racine

`loadDraft()` accepte n'importe quelle ligne draft retournée par `GET /api/save-draft?consultationId=…` et fait `setReport(report_content)` + `setShouldGenerateReport(false)`. Quand la même consultation a déjà été lancée (ex. les échecs CORS d'envoi pendant les tests), une ligne draft existe mais son `report_content` est vide/partiel → rapport blanc + refus de régénérer.

## Fix

Ne charger le draft que si `report_content.compteRendu.rapport` contient au moins un champ narratif non vide. Sinon, retomber sur la génération (même branche que "no draft found"). Appliqué à `dermatology-professional-report` et `professional-report` (general) — même pattern `loadDraft`, même bug.

## Test

- [ ] Relancer la consult dermato `420d84a5...` (qui a un draft vide existant) → le rapport doit se régénérer au lieu d'être blanc
- [ ] Vérifier general aussi

https://claude.ai/code/session_01PCkJ3ktUpfmSziunR8rauM

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCkJ3ktUpfmSziunR8rauM)_