### PR TITLE
feat(rag): verrouiller les citations sur la base RAG — appariement vérifié et statut des sources

### DIFF
--- a/app/api/chronic-diagnosis/route.ts
+++ b/app/api/chronic-diagnosis/route.ts
@@ -16,6 +16,7 @@ import {
   filterEvidenceRefsByTopic,
   type RAGContext,
 } from '@/lib/rag/medical-rag'
+import { verifyCitationGrounding } from '@/lib/rag/verify-citations'
 
 export const runtime = 'nodejs'
 export const maxDuration = 600 // 600s: chronic-diagnosis runs 2 sequential DeepSeek-V4-Pro reasoning calls (clinical analysis + structured plans). Each can take 150-250s, so the previous 300s cap was tripping FUNCTION_INVOCATION_TIMEOUT mid-stream.
@@ -466,7 +467,17 @@ Si une recommandation s'appuie sur une guideline du bloc CONTEXTE GUIDELINES MÉ
               },
             }
           )
-          combinedAssessment.evidence_references = topicFiltered.kept
+          // Grounding verification — the topic filter above compares TITLES
+          // only. This pass reads the guideline TEXT and removes citations it
+          // does not support. Prose untouched, fail-open.
+          const verifyResult = await verifyCitationGrounding(
+            combinedAssessment,
+            ragContext,
+            topicFiltered.kept,
+            ragResult.refUsageByPath,
+            { logPrefix: '🔒 [RAG-VERIFY-CHRONIC]' },
+          )
+          combinedAssessment.evidence_references = verifyResult.evidenceReferences
           combinedAssessment.rag_used = ragContext.ragUsed
           combinedAssessment.rag_metadata = {
             chunks_retrieved: ragContext.totalChunks,
@@ -478,6 +489,14 @@ Si une recommandation s'appuie sur une guideline du bloc CONTEXTE GUIDELINES MÉ
             hallucinated_refs_scrubbed: ragResult.hallucinatedRefsScrubbed,
             hallucinated_refs_breakdown: ragResult.hallucinatedRefsBreakdown,
             unused_refs_filtered: ragResult.unusedRefsFiltered,
+            // Grounding verification (lib/rag/verify-citations.ts)
+            grounding_verified: verifyResult.verified,
+            grounding_skipped_reason: verifyResult.skippedReason ?? null,
+            unsupported_refs_removed: verifyResult.removedRefIds.length,
+            unsupported_refs_breakdown: verifyResult.removedRefIds,
+            unverifiable_refs: verifyResult.unverifiableRefIds,
+            grounding_verdicts: verifyResult.verdicts,
+            grounding_latency_ms: verifyResult.latencyMs,
           }
 
           sendSSE('progress', { message: 'Évaluation terminée!', progress: 100 })

--- a/app/api/chronic-examens/route.ts
+++ b/app/api/chronic-examens/route.ts
@@ -14,6 +14,7 @@ import {
   filterEvidenceRefsByTopic,
   type RAGContext,
 } from '@/lib/rag/medical-rag'
+import { verifyCitationGrounding } from '@/lib/rag/verify-citations'
 
 export const runtime = 'nodejs'
 export const maxDuration = 600 // 600s: 2 sequential DeepSeek calls (labs/imaging + referrals/monitoring) can total 250-500s.
@@ -430,6 +431,18 @@ CONSULTATIONS selon maladies:
             }
           )
           ragResult.evidenceReferences = examsFiltered.kept
+          // Grounding verification — the topic filter above compares TITLES
+          // only. This pass reads the guideline TEXT and removes citations it
+          // does not support. Runs BEFORE the auto-cite below so the fallback
+          // can only pick a ref that survived verification.
+          const verifyResult = await verifyCitationGrounding(
+            combinedExamOrders,
+            ragContext,
+            ragResult.evidenceReferences,
+            ragResult.refUsageByPath,
+            { logPrefix: '🔒 [RAG-VERIFY-CHRONIC-EXAMENS]' },
+          )
+          ragResult.evidenceReferences = verifyResult.evidenceReferences
 
           // Defensive auto-cite: if a test/exam clinicalIndication doesn't
           // already contain [ref-N] and we have at least one evidence ref,
@@ -488,6 +501,14 @@ CONSULTATIONS selon maladies:
               hallucinated_refs_scrubbed: ragResult.hallucinatedRefsScrubbed,
               hallucinated_refs_breakdown: ragResult.hallucinatedRefsBreakdown,
               unused_refs_filtered: ragResult.unusedRefsFiltered,
+              // Grounding verification (lib/rag/verify-citations.ts)
+              grounding_verified: verifyResult.verified,
+              grounding_skipped_reason: verifyResult.skippedReason ?? null,
+              unsupported_refs_removed: verifyResult.removedRefIds.length,
+              unsupported_refs_breakdown: verifyResult.removedRefIds,
+              unverifiable_refs: verifyResult.unverifiableRefIds,
+              grounding_verdicts: verifyResult.verdicts,
+              grounding_latency_ms: verifyResult.latencyMs,
             },
             evidence_references: ragResult.evidenceReferences,
           })

--- a/app/api/chronic-prescription/route.ts
+++ b/app/api/chronic-prescription/route.ts
@@ -12,6 +12,7 @@ import {
   filterEvidenceRefsByTopic,
   type RAGContext,
 } from '@/lib/rag/medical-rag'
+import { verifyCitationGrounding } from '@/lib/rag/verify-citations'
 
 export const runtime = 'nodejs'
 export const maxDuration = 600 // 600s for DeepSeek-V4-Pro chronic prescription generation
@@ -500,6 +501,17 @@ Generate the comprehensive chronic disease prescription now.`
       }
     )
     ragResult.evidenceReferences = presFiltered.kept
+    // Grounding verification — the topic filter above compares TITLES only.
+    // This pass reads the guideline TEXT and removes citations it does not
+    // support. Prose untouched, fail-open.
+    const verifyResult = await verifyCitationGrounding(
+      prescriptionData,
+      ragContext,
+      ragResult.evidenceReferences,
+      ragResult.refUsageByPath,
+      { logPrefix: '🔒 [RAG-VERIFY-CHRONIC-PRESCRIPTION]' },
+    )
+    ragResult.evidenceReferences = verifyResult.evidenceReferences
 
     // Defensive auto-cite: if a chronicMedication's indication.clinicalRationale
     // doesn't already contain [ref-N] and we have at least one evidence ref,
@@ -551,6 +563,14 @@ Generate the comprehensive chronic disease prescription now.`
         hallucinated_refs_scrubbed: ragResult.hallucinatedRefsScrubbed,
         hallucinated_refs_breakdown: ragResult.hallucinatedRefsBreakdown,
         unused_refs_filtered: ragResult.unusedRefsFiltered,
+        // Grounding verification (lib/rag/verify-citations.ts)
+        grounding_verified: verifyResult.verified,
+        grounding_skipped_reason: verifyResult.skippedReason ?? null,
+        unsupported_refs_removed: verifyResult.removedRefIds.length,
+        unsupported_refs_breakdown: verifyResult.removedRefIds,
+        unverifiable_refs: verifyResult.unverifiableRefIds,
+        grounding_verdicts: verifyResult.verdicts,
+        grounding_latency_ms: verifyResult.latencyMs,
       },
       evidence_references: ragResult.evidenceReferences,
     })

--- a/app/api/dermatology-diagnosis/route.ts
+++ b/app/api/dermatology-diagnosis/route.ts
@@ -19,6 +19,7 @@ import {
   queryMedicalGuidelinesMulti,
   fetchGuidelineChunksByTitlePatterns,
   mergeTitlePatternRowsIntoContext,
+  attachContentKind,
   formatGuidelinesForPrompt,
   scrubAndEnrichEvidenceRefs,
   filterEvidenceRefsByTopic,
@@ -1083,6 +1084,11 @@ GENERATE your EXPERT dermatological assessment with MAXIMUM clinical specificity
           )
         }
       }
+      // The title-pattern merge is synchronous and bypasses the query entry
+      // points, so guidelines pulled in by TITLE arrive unlabelled. Re-run the
+      // labelling over the merged context — one query on a handful of ids,
+      // idempotent for those already labelled.
+      ragContext = await attachContentKind(ragContext)
       console.log(
         `📚 [RAG-DERMA] Final context: ${ragContext.totalChunks} chunks ` +
           `(avg similarity ${ragContext.avgSimilarity.toFixed(2)}, refs: ${ragContext.references.length})`

--- a/app/api/dermatology-diagnosis/route.ts
+++ b/app/api/dermatology-diagnosis/route.ts
@@ -25,6 +25,7 @@ import {
   normaliseDiagnosticProbabilities,
   type RAGContext,
 } from '@/lib/rag/medical-rag'
+import { verifyCitationGrounding } from '@/lib/rag/verify-citations'
 
 // ==================== DATA ANONYMIZATION ====================
 function anonymizePatientData(patientData: any): {
@@ -1138,8 +1139,18 @@ GENERATE your EXPERT dermatological assessment with MAXIMUM clinical specificity
         },
       }
     )
-    const evidenceReferences = topicFiltered.kept
-    
+    // Grounding verification — the topic filter above only compares the ref
+    // TITLE with the diagnosis. This pass reads the guideline TEXT and drops
+    // citations it does not support. Prose untouched, fail-open.
+    const verifyResult = await verifyCitationGrounding(
+      diagnosisData,
+      ragContext,
+      topicFiltered.kept,
+      ragResult.refUsageByPath,
+      { logPrefix: '🔒 [RAG-VERIFY-DERMA]' },
+    )
+    const evidenceReferences = verifyResult.evidenceReferences
+
     // Generate formatted text for backward compatibility
     const fullTextDiagnosis = generateFormattedDiagnosisText(diagnosisData)
 
@@ -1500,6 +1511,14 @@ GENERATE your EXPERT dermatological assessment with MAXIMUM clinical specificity
         hallucinated_refs_scrubbed: ragResult.hallucinatedRefsScrubbed,
         hallucinated_refs_breakdown: ragResult.hallucinatedRefsBreakdown,
         unused_refs_filtered: ragResult.unusedRefsFiltered,
+        // Grounding verification (lib/rag/verify-citations.ts)
+        grounding_verified: verifyResult.verified,
+        grounding_skipped_reason: verifyResult.skippedReason ?? null,
+        unsupported_refs_removed: verifyResult.removedRefIds.length,
+        unsupported_refs_breakdown: verifyResult.removedRefIds,
+        unverifiable_refs: verifyResult.unverifiableRefIds,
+        grounding_verdicts: verifyResult.verdicts,
+        grounding_latency_ms: verifyResult.latencyMs,
       },
       evidence_references: evidenceReferences,
 

--- a/app/api/openai-diagnosis/route.ts
+++ b/app/api/openai-diagnosis/route.ts
@@ -12,6 +12,7 @@ import {
   inferSpecialty,
   buildClinicalQuery,
   scrubAndEnrichEvidenceRefs,
+  filterEvidenceRefsByTopic,
   normaliseDiagnosticProbabilities,
   type RAGContext,
   type RAGReference,
@@ -5868,6 +5869,46 @@ console.log(`🏝️ Niveau de qualité utilisé : ${mauritius_quality_level}`)
     // lib/rag/medical-rag.ts so all three flows behave identically.
     const ragResult = scrubAndEnrichEvidenceRefs(finalAnalysis, ragContext)
 
+    // ============ RAG: TOPIC-MATCH SAFETY NET ============
+    // Every other citing flow (dermatology, chronic, chronic-examens,
+    // chronic-prescription) already ran this; the general consultation — the
+    // most used one, and the one whose prompt pushes hardest to cite
+    // ("MINIMUM 3 references", "when in doubt PREFER citing") — did not.
+    // Hard-drops refs whose subject is outside the patient's context
+    // (pregnancy on a non-pregnant patient, paediatric on an adult, oncology
+    // with no cancer history) and soft-drops those whose title shares no
+    // substantive token with the diagnosis.
+    const generalTopicSeeds: string[] = [
+      finalAnalysis?.clinical_analysis?.primary_diagnosis?.condition || '',
+      finalAnalysis?.clinical_analysis?.primary_diagnosis?.diagnosis || '',
+      finalAnalysis?.clinical_analysis?.primary_diagnosis?.name || '',
+      ...(Array.isArray(finalAnalysis?.clinical_analysis?.differential_diagnoses)
+        ? finalAnalysis.clinical_analysis.differential_diagnoses.map(
+            (d: any) => d?.condition || d?.diagnosis || d?.name || ''
+          )
+        : []),
+      patientContext.chief_complaint || '',
+      ...(Array.isArray(patientContext.symptoms) ? patientContext.symptoms : []),
+    ].filter((s: any) => typeof s === 'string' && s.length > 0)
+    const ageForFlags = typeof patientContext.age === 'number'
+      ? patientContext.age
+      : parseInt(String(patientContext.age ?? ''), 10)
+    const generalTopicFiltered = filterEvidenceRefsByTopic(
+      ragResult.evidenceReferences,
+      generalTopicSeeds,
+      {
+        logPrefix: '🎯 [TOPIC-FILTER-GENERAL]',
+        patientFlags: {
+          isPregnant: /\b(pregn|enceinte|gestational|gravid)/i.test(String(patientContext.pregnancy_status || '')),
+          isChild: Number.isFinite(ageForFlags) ? ageForFlags < 18 : false,
+          hasCancer: Array.isArray(patientContext.medical_history) &&
+            patientContext.medical_history.some((d: string) =>
+              /\b(cancer|carcinoma|melanoma|lymphoma|leukemi|leukaemi|sarcoma|metastat|oncolog|tumou?r|neoplas)/i.test(String(d || ''))
+            ),
+        },
+      }
+    )
+
     // ============ RAG: GROUNDING VERIFICATION ============
     // The scrub above proves each [ref-N] points at a guideline we really
     // retrieved. It does NOT prove that guideline says anything about the
@@ -5878,7 +5919,7 @@ console.log(`🏝️ Niveau de qualité utilisé : ${mauritius_quality_level}`)
     const verifyResult = await verifyCitationGrounding(
       finalAnalysis,
       ragContext,
-      ragResult.evidenceReferences,
+      generalTopicFiltered.kept,
       ragResult.refUsageByPath,
       { logPrefix: '🔒 [RAG-VERIFY]' },
     )

--- a/app/api/openai-diagnosis/route.ts
+++ b/app/api/openai-diagnosis/route.ts
@@ -17,6 +17,7 @@ import {
   type RAGReference,
 } from '@/lib/rag/medical-rag'
 import { reRankAndShrinkContext } from '@/lib/rag/rerank'
+import { verifyCitationGrounding } from '@/lib/rag/verify-citations'
 
 export const runtime = 'nodejs'
 export const maxDuration = 600 // 600s: DeepSeek-V4-Pro on the Phase 1 enriched system prompt + Phase 2 boosted RAG context regularly runs 250-350s; 600 gives headroom without burning more compute than the call actually uses (Vercel bills real runtime, not the cap).
@@ -5866,7 +5867,22 @@ console.log(`🏝️ Niveau de qualité utilisé : ${mauritius_quality_level}`)
     // Shared with chronic-diagnosis and dermatology-diagnosis via the helper in
     // lib/rag/medical-rag.ts so all three flows behave identically.
     const ragResult = scrubAndEnrichEvidenceRefs(finalAnalysis, ragContext)
-    const evidenceReferences = ragResult.evidenceReferences
+
+    // ============ RAG: GROUNDING VERIFICATION ============
+    // The scrub above proves each [ref-N] points at a guideline we really
+    // retrieved. It does NOT prove that guideline says anything about the
+    // sentence it is attached to — every check so far reasons on the title.
+    // This pass reads the actual chunk text and removes citations the
+    // guideline does not support. Narrative prose is never modified.
+    // Fail-open: on any error the bibliography is returned untouched.
+    const verifyResult = await verifyCitationGrounding(
+      finalAnalysis,
+      ragContext,
+      ragResult.evidenceReferences,
+      ragResult.refUsageByPath,
+      { logPrefix: '🔒 [RAG-VERIFY]' },
+    )
+    const evidenceReferences = verifyResult.evidenceReferences
     const unknownCitedRefs = ragResult.unknownCitedRefs
     const citationsReconstructed = ragResult.citationsReconstructed
     const hallucinatedRefsScrubbed = ragResult.hallucinatedRefsScrubbed
@@ -5905,6 +5921,14 @@ console.log(`🏝️ Niveau de qualité utilisé : ${mauritius_quality_level}`)
         hallucinated_refs_scrubbed: hallucinatedRefsScrubbed,
         hallucinated_refs_breakdown: hallucinatedRefsBreakdown,
         unused_refs_filtered: unusedRefsFiltered,
+        // Grounding verification (lib/rag/verify-citations.ts)
+        grounding_verified: verifyResult.verified,
+        grounding_skipped_reason: verifyResult.skippedReason ?? null,
+        unsupported_refs_removed: verifyResult.removedRefIds.length,
+        unsupported_refs_breakdown: verifyResult.removedRefIds,
+        unverifiable_refs: verifyResult.unverifiableRefIds,
+        grounding_verdicts: verifyResult.verdicts,
+        grounding_latency_ms: verifyResult.latencyMs,
       },
       evidence_references: evidenceReferences,
 

--- a/components/rag/evidence-references-section.tsx
+++ b/components/rag/evidence-references-section.tsx
@@ -14,6 +14,8 @@
 
 import React from 'react'
 
+type GuidelineContentKind = 'referentiel' | 'recherche' | 'notice' | 'indetermine'
+
 interface EvidenceReference {
   ref_id?: string
   title?: string
@@ -23,6 +25,36 @@ interface EvidenceReference {
   publication_date?: string
   specialty?: string
   used_for?: string
+  /** Nature of the source, read from guideline_content_kind server-side. */
+  content_kind?: GuidelineContentKind
+}
+
+/**
+ * What the reader is told about a source that is NOT a society guideline.
+ *
+ * A third of the corpus is primary research and an eighth is a bibliographic
+ * pointer whose full text was never retrieved. Listing all of them under
+ * "international medical guidelines" — as this section did until now — lends
+ * a 53-patient cohort the authority of a learned society. A title alone
+ * cannot be trusted to say what a document is, so we say it explicitly.
+ *
+ * `referentiel` gets no badge on purpose: it IS what the section header
+ * already claims, and badging the normal case only adds noise.
+ */
+const KIND_BADGE: Record<GuidelineContentKind, { label: string; className: string } | null> = {
+  referentiel: null,
+  recherche: {
+    label: 'Étude — pas une recommandation de société savante',
+    className: 'bg-amber-50 text-amber-800 border-amber-200',
+  },
+  notice: {
+    label: 'Notice bibliographique — texte intégral non consulté',
+    className: 'bg-gray-100 text-gray-700 border-gray-300',
+  },
+  indetermine: {
+    label: 'Statut non confirmé',
+    className: 'bg-gray-100 text-gray-700 border-gray-300',
+  },
 }
 
 interface Props {
@@ -63,8 +95,9 @@ export default function EvidenceReferencesSection({ references }: Props) {
         Références médicales utilisées
       </h2>
       <p className="text-sm text-gray-700 mb-4">
-        Ce diagnostic et ces recommandations s'appuient sur les guidelines
-        médicales internationales suivantes :
+        Ce diagnostic et ces recommandations s'appuient sur les sources
+        médicales internationales suivantes. Les sources qui ne sont pas des
+        recommandations de société savante sont signalées comme telles :
       </p>
       <ol className="space-y-4 text-sm text-gray-700">
         {refs.map((ref, idx) => {
@@ -73,12 +106,22 @@ export default function EvidenceReferencesSection({ references }: Props) {
           const date = formatDate(ref.publication_date)
           const url = ref.url?.trim()
           const usedFor = ref.used_for?.trim()
+          const badge = ref.content_kind ? KIND_BADGE[ref.content_kind] : null
           return (
             <li key={`${ref.ref_id || ref.external_id || idx}`} className="break-inside-avoid">
               <div className="flex gap-2">
                 <span className="font-semibold shrink-0">[{idx + 1}]</span>
                 <div className="flex-1 space-y-1">
                   <p className="font-semibold text-gray-900">{title}</p>
+                  {badge && (
+                    <p>
+                      <span
+                        className={`inline-block px-2 py-0.5 rounded border text-[11px] font-medium ${badge.className}`}
+                      >
+                        {badge.label}
+                      </span>
+                    </p>
+                  )}
                   {date && (
                     <p className="text-xs text-gray-600">Publié : {date}</p>
                   )}

--- a/lib/rag/medical-rag.ts
+++ b/lib/rag/medical-rag.ts
@@ -105,6 +105,13 @@ export type SpecialtyCode =
 
 /** Raw row shape returned by public.match_guidelines RPC. */
 interface MatchGuidelinesRow {
+  /**
+   * Document id. Verified present in the RPC's return type on
+   * tibok-production — it is what joins a chunk to guideline_content_kind.
+   * Optional here anyway: a deployment whose RPC drops the column must
+   * degrade to "unlabelled", never to a crash.
+   */
+  guideline_id?: string
   guideline_title: string
   guideline_external_id: string
   source_code: string
@@ -123,6 +130,29 @@ export interface RAGChunk {
   refId: string
 }
 
+/**
+ * What the text indexed under this title actually IS.
+ *
+ * Read from guideline_content_kind, computed ONCE over the whole document
+ * (a 6000-char slice taken from the middle of a real guideline — a dosing
+ * table, an appendix — carries no "we recommend", so the same test applied
+ * per-chunk would misclassify impeccable guidelines as primary literature).
+ *
+ * Measured on the live corpus (6315 documents, 2026-08-01):
+ *   referentiel  2092 (33%)  carries recommendation language
+ *   recherche    2019 (32%)  reports a study — NOT a society recommendation
+ *   indetermine  1425 (23%)  neither, clearly
+ *   notice        779 (12%)  bibliographic pointer, full text never retrieved
+ *
+ * So roughly 44% of what this pipeline can cite is not a society guideline —
+ * and until now every one of them was presented to the doctor under the same
+ * "international medical guidelines" heading. This field exists to LABEL a
+ * citation, never to filter one: a cohort study belongs in clinical
+ * reasoning, it simply does not carry the authority of a learned society,
+ * and the report has to say so.
+ */
+export type GuidelineContentKind = 'referentiel' | 'recherche' | 'notice' | 'indetermine'
+
 export interface RAGReference {
   /** Citation tag injected in the prompt (e.g. "ref-1"). */
   ref_id: string
@@ -132,6 +162,10 @@ export interface RAGReference {
   url: string
   publication_date: string
   specialty: string
+  /** Document id, used to join guideline_content_kind. Absent when the RPC drops it. */
+  guideline_id?: string
+  /** Nature of the source. Undefined = not established; treat as unlabelled, never as authoritative. */
+  content_kind?: GuidelineContentKind
 }
 
 export interface RAGContext {
@@ -198,7 +232,10 @@ export async function queryMedicalGuidelines(
   const rows = await fetchGuidelineRows(trimmedQuery, { specialty, threshold, limit })
   if (rows === null) return { ...EMPTY_CONTEXT, ragUsed: false }
   if (rows.length === 0) return { ...EMPTY_CONTEXT, ragUsed: true }
-  return buildContextFromRows(rows)
+  // Label the nature of each source before anything downstream reads the
+  // context. Done at the entry point so every caller gets it for free — a
+  // route must not be able to forget it.
+  return attachContentKind(buildContextFromRows(rows))
 }
 
 /**
@@ -301,7 +338,7 @@ export async function queryMedicalGuidelinesMulti(
       `in ${Date.now() - t0}ms (deduped ${allRows.length - dedupedRows.length})`
   )
 
-  const ctx = buildContextFromRows(dedupedRows)
+  const ctx = await attachContentKind(buildContextFromRows(dedupedRows))
   return { ...ctx, ragUsed: ragUsed && ctx.ragUsed }
 }
 
@@ -477,6 +514,7 @@ function buildContextFromRows(rows: MatchGuidelinesRow[]): RAGContext {
         url: row.source_url || '',
         publication_date: row.source_publication_date || '',
         specialty: row.specialty_code || '',
+        guideline_id: row.guideline_id,
       }
       refByExternalId.set(externalId, ref)
     }
@@ -499,6 +537,131 @@ function buildContextFromRows(rows: MatchGuidelinesRow[]): RAGContext {
     avgSimilarity,
     ragUsed: true,
   }
+}
+
+/**
+ * A BIBLIOGRAPHIC POINTER, not the text of a recommendation.
+ *
+ * 779 documents of the corpus (12%) were indexed by the `citation-stub`
+ * method: the full text was not freely retrievable (proprietary access,
+ * member portal), and the ingestion recorded a pointer instead. They declare
+ * themselves:
+ *
+ *   "This is a citation reference for the ANSM guideline '…' published in
+ *    2024. The full text was not freely retrievable at the time of indexing…"
+ *
+ * These are not fake references — they are honest pointers, and dropping them
+ * would be wrong: knowing that a recommendation exists on the subject has
+ * value. The danger is the model citing one AS IF it carried a recommendation
+ * and inventing the missing content. So we label it for what it is.
+ *
+ * Detected on the TEXT, so it still works when the content_kind lookup fails.
+ */
+const CITATION_STUB_RE =
+  /this is a citation (?:reference|stub) for|full text was not freely retrievable/i
+
+export function isCitationStub(content: string): boolean {
+  return CITATION_STUB_RE.test(String(content || ''))
+}
+
+/**
+ * Label each reference with the nature of its source.
+ *
+ * One query, on the handful of guidelines actually retrieved — not on the
+ * corpus. Falls back to the self-declaring citation-stub text when the table
+ * lookup yields nothing for a reference.
+ *
+ * Fails SILENTLY: without this signal we label less precisely, we do not
+ * return fewer references. A missing table must never cost a report its
+ * bibliography.
+ */
+export async function attachContentKind(ctx: RAGContext): Promise<RAGContext> {
+  if (!ctx.ragUsed || ctx.references.length === 0) return ctx
+
+  // Text-based fallback first — it needs no database at all.
+  const stubExternalIds = new Set<string>()
+  for (const chunk of ctx.chunks) {
+    if (isCitationStub(chunk.content)) {
+      const ref = ctx.references.find(r => r.ref_id === chunk.refId)
+      if (ref) stubExternalIds.add(ref.external_id)
+    }
+  }
+
+  const kindByGuidelineId = new Map<string, GuidelineContentKind>()
+  const ids = Array.from(
+    new Set(ctx.references.map(r => r.guideline_id).filter((v): v is string => !!v))
+  )
+  if (ids.length > 0) {
+    try {
+      const t0 = Date.now()
+      const { data, error } = await getSupabase()
+        .from('guideline_content_kind')
+        .select('guideline_id, kind')
+        .in('guideline_id', ids)
+      if (error) {
+        console.warn(`[RAG] content_kind lookup failed (non-blocking): ${error.message}`)
+      } else {
+        for (const row of (data || []) as Array<{ guideline_id: string; kind: string }>) {
+          const k = String(row.kind || '')
+          if (k === 'referentiel' || k === 'recherche' || k === 'notice' || k === 'indetermine') {
+            kindByGuidelineId.set(row.guideline_id, k)
+          }
+        }
+        console.log(
+          `[RAG] content_kind resolved for ${kindByGuidelineId.size}/${ids.length} guideline(s) in ${Date.now() - t0}ms`
+        )
+      }
+    } catch (err: any) {
+      console.warn('[RAG] content_kind lookup threw (non-blocking):', err?.message || err)
+    }
+  } else {
+    console.warn(
+      '[RAG] no guideline_id on any reference — content_kind labelling INOPERATIVE ' +
+        '(the RPC did not project the column); falling back to citation-stub text detection only.'
+    )
+  }
+
+  const references = ctx.references.map(ref => {
+    const fromTable = ref.guideline_id ? kindByGuidelineId.get(ref.guideline_id) : undefined
+    const kind: GuidelineContentKind | undefined =
+      fromTable ?? (stubExternalIds.has(ref.external_id) ? 'notice' : undefined)
+    return kind ? { ...ref, content_kind: kind } : ref
+  })
+
+  const mix = references.reduce<Record<string, number>>((acc, r) => {
+    const k = r.content_kind ?? 'unlabelled'
+    acc[k] = (acc[k] || 0) + 1
+    return acc
+  }, {})
+  console.log(`[RAG] source nature: ${JSON.stringify(mix)}`)
+
+  return { ...ctx, references }
+}
+
+/** Prompt-side warning carried right next to the excerpt the model reads. */
+function contentKindWarning(ref: RAGReference): string {
+  if (ref.content_kind === 'notice') {
+    return (
+      '\n⚠ POINTER ONLY — the full text of this guideline was NOT retrieved. You may state ' +
+      'that this guideline exists and is relevant to the topic. You must NOT attribute any ' +
+      'recommendation, threshold, dose or figure to it, and you must NOT infer its content.'
+    )
+  }
+  if (ref.content_kind === 'recherche') {
+    return (
+      '\n⚠ PRIMARY RESEARCH, not a society guideline — despite the title above, this text ' +
+      'reports a study (cohort, trial or review). Cite it as study evidence ("a study reports…"). ' +
+      'Do NOT write "according to the X recommendation" and do NOT attach a recommendation grade to it.'
+    )
+  }
+  if (ref.content_kind === 'indetermine') {
+    return (
+      '\n⚠ STATUS UNCONFIRMED — this text could not be established as carrying society ' +
+      'recommendation language. Use it to inform reasoning, but do not present it as a formal ' +
+      'recommendation.'
+    )
+  }
+  return ''
 }
 
 /**
@@ -542,6 +705,13 @@ export function formatGuidelinesForPrompt(ctx: RAGContext): string {
     const refChunks = chunksByRef.get(ref.ref_id) ?? []
     const date = ref.publication_date ? ` (${ref.publication_date})` : ''
     lines.push(`[${ref.ref_id}] ${ref.source} ${ref.external_id}${date} — ${ref.title}`)
+    // Status warning FIRST, before the URL and the text: the status matters as
+    // much as the content. An excerpt announced under a "CHEST guideline"
+    // title whose text is a 53-patient cohort must be cited as a study, not
+    // as a learned-society recommendation — otherwise the report lends a case
+    // series the authority of a reference standard.
+    const kindWarning = contentKindWarning(ref)
+    if (kindWarning) lines.push(kindWarning.replace(/^\n/, ''))
     if (ref.url) lines.push(`URL: ${ref.url}`)
     if (ref.specialty) lines.push(`Specialty: ${ref.specialty}`)
     for (const chunk of refChunks) {
@@ -585,6 +755,9 @@ export function formatGuidelinesForPrompt(ctx: RAGContext): string {
   )
   lines.push(
     "9. NE PAS inventer de références: ne cite que les [ref-N] présents ci-dessus."
+  )
+  lines.push(
+    "10. STATUT DE LA SOURCE: respecte l'avertissement ⚠ attaché à une référence. Une source marquée PRIMARY RESEARCH se cite comme une étude, jamais comme une recommandation de société savante. Une source marquée POINTER ONLY peut être signalée comme existante et pertinente, mais AUCUN chiffre, seuil, dose ni recommandation ne peut lui être attribué — ne devine jamais son contenu."
   )
   lines.push('')
 
@@ -1567,14 +1740,31 @@ export function scrubAndEnrichEvidenceRefs(
   }
 
   // Pass 2 — fallback if LLM emitted nothing despite chunks being available.
+  //
+  // ONLY refs the model actually cited in the prose are reconstructed. The
+  // previous version had a second branch: when NOTHING was cited anywhere, it
+  // listed every retrieved ref. That produced a bibliography of guidelines the
+  // report never used — the reader sees sources presented as having informed
+  // the reasoning when none of them did. It is the same fabricated attribution
+  // that got Pass 3 removed (see below), just quieter: Pass 3 padded a partial
+  // list, this branch invented the whole one.
+  //
+  // A report the model wrote without citing anything is a report based on
+  // clinical practice, and saying so is the honest outcome. The bibliography
+  // stays empty and EvidenceReferencesSection renders its "standard clinical
+  // practice" note.
   if (evidenceReferences.length === 0 && ragContext.references.length > 0) {
-    citationsReconstructed = true
-    const fallbackRefs = usedValidRefs.size > 0
-      ? ragContext.references.filter(r => usedValidRefs.has(r.ref_id))
-      : ragContext.references
-    console.log(
-      `${tag} Reconstructing ${fallbackRefs.length} citation(s) — LLM emitted empty evidence_references despite ${ragContext.totalChunks} chunks provided ` +
-        `(narrative-cited: ${usedValidRefs.size}, full-fallback: ${usedValidRefs.size === 0})`
+    const fallbackRefs = ragContext.references.filter(r => usedValidRefs.has(r.ref_id))
+    if (fallbackRefs.length === 0) {
+      console.warn(
+        `${tag} LLM emitted empty evidence_references AND cited no [ref-N] anywhere in the report, ` +
+          `despite ${ragContext.totalChunks} chunk(s) provided. Bibliography left EMPTY — listing ` +
+          `uncited refs would attribute the reasoning to guidelines the report never used.`
+      )
+    }
+    citationsReconstructed = fallbackRefs.length > 0
+    if (fallbackRefs.length > 0) console.log(
+      `${tag} Reconstructing ${fallbackRefs.length} citation(s) — LLM emitted empty evidence_references but DID cite them in the narrative`
     )
     for (const ref of fallbackRefs) {
       evidenceReferences.push({

--- a/lib/rag/verify-citations.ts
+++ b/lib/rag/verify-citations.ts
@@ -1,0 +1,388 @@
+// lib/rag/verify-citations.ts
+//
+// GROUNDING VERIFICATION — the missing lock in the RAG chain.
+//
+// What the existing chain already guarantees (see medical-rag.ts):
+//   - a [ref-N] token that points outside the retrieved set is stripped
+//   - a ref listed in evidence_references but never cited in the prose is dropped
+//   - title / source / URL / date are joined from the corpus row, never from
+//     the model — so a fabricated LINK is impossible by construction
+//   - filterEvidenceRefsByTopic drops refs whose TITLE has no overlap with the
+//     diagnosis, and hard-drops obvious patient-context mismatches
+//
+// What NONE of those check: whether the guideline text actually says anything
+// about the sentence it is attached to. Every filter so far reasons on the
+// TITLE. `chunk_content` — the only thing that can settle it — was read to
+// build the prompt and to re-rank, never to verify an attribution.
+//
+// The failure mode this closes is specific and invisible in the logs: a real
+// NICE / CDC / ESC guideline, correctly retrieved, correctly linked, attached
+// to a dosage or a threshold it does not contain. The reader sees an
+// authoritative reference next to a claim it does not support. That is worse
+// than no citation at all, because the reference lends its authority to
+// something it never said.
+//
+// HOW IT WORKS
+//   One LLM call per consultation. For each cited ref we send the guideline
+//   text and the exact narrative excerpts where the model placed [ref-N], and
+//   ask a single question: does this text bear on these claims?
+//
+// DELIBERATE ASYMMETRY
+//   The verifier defaults to `supported: true`. Only an explicit
+//   `supported: false` removes anything. Rationale: the cost of the two errors
+//   is not symmetric here. Dropping a legitimate citation makes a sound report
+//   look unsourced; keeping a wrong one makes an unsound claim look sourced.
+//   But this pass runs LAST, after three filters have already removed the
+//   easy cases — anything reaching it is plausible enough that a strict
+//   verifier would mostly be wrong. So it only fires on clear mismatches.
+//
+// WHAT IS REMOVED, AND WHAT IS NOT
+//   Only the [ref-N] markers and the bibliography entry. The medical prose is
+//   never touched: an unsupported citation means "this sentence is not sourced
+//   by that guideline", NOT "this sentence is wrong". Removing the clinical
+//   content on a bibliographic signal would be a much worse failure than the
+//   one being fixed.
+//
+// FAIL-OPEN
+//   Timeout, parse error, empty verdicts, missing ref in the response → the
+//   citation is kept and the consultation proceeds unchanged. Same contract as
+//   retrieval and re-rank: RAG never blocks a consultation.
+
+import { callLLM } from '@/lib/llm-client'
+import type { RAGContext, RAGReference } from './medical-rag'
+
+/** An evidence reference as produced by scrubAndEnrichEvidenceRefs. */
+export type EnrichedRef = RAGReference & { used_for?: string }
+
+export interface CitationVerdict {
+  ref_id: string
+  supported: boolean
+  reason: string
+}
+
+export interface VerifyCitationsResult {
+  /** The bibliography with unsupported refs removed. */
+  evidenceReferences: EnrichedRef[]
+  /** ref_ids removed because the guideline text did not support the claim. */
+  removedRefIds: string[]
+  /** Per-ref verdicts as returned by the verifier (audit log). */
+  verdicts: CitationVerdict[]
+  /** True when the verification pass actually ran and produced verdicts. */
+  verified: boolean
+  /** Set when the pass was skipped or failed — why. */
+  skippedReason?: string
+  /** Number of [ref-N] tokens stripped from the narrative. */
+  tokensStripped: number
+  /**
+   * Refs kept without being verified because no narrative excerpt was
+   * attached to them (typically the Pass-2 reconstruction path, which lists
+   * refs the model never cited). Nothing to check against — kept, but
+   * counted so the gap stays visible in rag_metadata.
+   */
+  unverifiableRefIds: string[]
+  latencyMs: number
+}
+
+export interface VerifyCitationsOptions {
+  logPrefix?: string
+  /** Default 45s. The pass is auxiliary — it must not extend the consultation. */
+  timeoutMs?: number
+  /** Model override; falls back to RAG_VERIFY_MODEL, then callLLM resolution. */
+  model?: string
+  /** Max narrative excerpts sent per ref. Default 3. */
+  maxExcerptsPerRef?: number
+  /** Max guideline characters sent per ref. Default 1800. */
+  maxChunkCharsPerRef?: number
+}
+
+const DEFAULT_TIMEOUT_MS = 45_000
+const DEFAULT_MAX_EXCERPTS = 3
+const DEFAULT_MAX_CHUNK_CHARS = 1800
+
+const REF_TOKEN_GLOBAL = /\[ref-(\d+)\]/g
+
+const SYSTEM_PROMPT = `You are a medical fact-checker auditing citations in a clinical report.
+
+For each item you receive: the text of a clinical guideline, and the sentences from the report where that guideline was cited.
+
+ONE question per item: does the guideline text BEAR ON those sentences?
+
+Mark supported = true when the guideline text addresses the same clinical subject as the claim — the same condition, drug, test, threshold, population or management step. Partial or indirect support counts: a guideline discussing the management of the condition supports a statement about treating it, even if it does not repeat the exact wording.
+
+Mark supported = false ONLY when the guideline text is clearly about something else — a different disease, a different drug class, a different population — so that a clinician reading the report would be misled into thinking this guideline backs a claim it never addresses.
+
+WHEN IN DOUBT, ANSWER TRUE. You are looking for clear mismatches, not imperfect matches. A partially relevant citation stays.
+
+Return JSON ONLY, no prose:
+{ "verdicts": [ { "ref_id": "ref-1", "supported": true, "reason": "<max 15 words>" } ] }
+
+Return a verdict for EVERY ref_id you were given.`
+
+/**
+ * Strip the given [ref-N] tokens from every string in an object tree.
+ *
+ * Mutates in place. `evidence_references` and `rag_metadata` are skipped so
+ * the structured bibliography is not rewritten by a narrative pass — the
+ * caller filters those explicitly.
+ */
+function stripRefTokens(
+  node: any,
+  idsToRemove: ReadonlySet<string>,
+  counter: { n: number },
+  excludeKeys: ReadonlySet<string> = new Set(['evidence_references', 'rag_metadata']),
+): any {
+  if (idsToRemove.size === 0) return node
+  const visit = (n: any): any => {
+    if (typeof n === 'string') {
+      if (!n.includes('[ref-')) return n
+      let modified = false
+      const cleaned = n.replace(REF_TOKEN_GLOBAL, (match, num) => {
+        if (!idsToRemove.has(`ref-${num}`)) return match
+        modified = true
+        counter.n++
+        return ''
+      })
+      if (!modified) return n
+      return cleaned
+        .replace(/\s+([,.;:!?)])/g, '$1')
+        .replace(/\(\s*\)/g, '')
+        .replace(/\s{2,}/g, ' ')
+        .trim()
+    }
+    if (Array.isArray(n)) {
+      for (let i = 0; i < n.length; i++) n[i] = visit(n[i])
+      return n
+    }
+    if (n && typeof n === 'object') {
+      for (const k of Object.keys(n)) {
+        if (excludeKeys.has(k)) continue
+        n[k] = visit(n[k])
+      }
+    }
+    return n
+  }
+  return visit(node)
+}
+
+/** Collect the guideline text belonging to a ref, deduped and truncated. */
+function guidelineTextForRef(ctx: RAGContext, refId: string, maxChars: number): string {
+  const parts: string[] = []
+  const seen = new Set<string>()
+  for (const chunk of ctx.chunks) {
+    if (chunk.refId !== refId) continue
+    const content = (chunk.content || '').trim()
+    if (!content) continue
+    const key = content.slice(0, 120)
+    if (seen.has(key)) continue
+    seen.add(key)
+    parts.push(chunk.section ? `[${chunk.section}] ${content}` : content)
+  }
+  const joined = parts.join('\n---\n')
+  return joined.length > maxChars ? `${joined.slice(0, maxChars)}…` : joined
+}
+
+/**
+ * Verify that every cited guideline actually bears on the claim it is attached
+ * to, and remove the citations that do not.
+ *
+ * Runs LAST in the RAG chain — after scrubAndEnrichEvidenceRefs and, where the
+ * route has one, after filterEvidenceRefsByTopic. By then the bibliography is
+ * small (typically 2-6 refs), so a single call is enough.
+ *
+ * Never throws. On any failure the input bibliography is returned unchanged
+ * with `verified: false` and a `skippedReason`.
+ */
+export async function verifyCitationGrounding(
+  analysis: any,
+  ragContext: RAGContext,
+  evidenceReferences: EnrichedRef[],
+  refUsageByPath: Map<string, Array<{ path: string; excerpt: string }>>,
+  options: VerifyCitationsOptions = {},
+): Promise<VerifyCitationsResult> {
+  const tag = options.logPrefix || '🔒 [RAG-VERIFY]'
+  const t0 = Date.now()
+  const refs = Array.isArray(evidenceReferences) ? evidenceReferences : []
+
+  const base: VerifyCitationsResult = {
+    evidenceReferences: refs,
+    removedRefIds: [],
+    verdicts: [],
+    verified: false,
+    tokensStripped: 0,
+    unverifiableRefIds: [],
+    latencyMs: 0,
+  }
+
+  if (refs.length === 0) {
+    return { ...base, skippedReason: 'no-refs', latencyMs: Date.now() - t0 }
+  }
+  if (!ragContext?.ragUsed || !Array.isArray(ragContext.chunks) || ragContext.chunks.length === 0) {
+    return { ...base, skippedReason: 'no-chunks', latencyMs: Date.now() - t0 }
+  }
+
+  const maxExcerpts = options.maxExcerptsPerRef ?? DEFAULT_MAX_EXCERPTS
+  const maxChunkChars = options.maxChunkCharsPerRef ?? DEFAULT_MAX_CHUNK_CHARS
+
+  // Build one verification item per ref that has at least one claim attached.
+  const items: Array<{ ref_id: string; title: string; source: string; guideline_text: string; claims: string[] }> = []
+  const unverifiableRefIds: string[] = []
+
+  for (const ref of refs) {
+    const refId = String(ref?.ref_id || '').trim()
+    if (!refId) continue
+
+    const usages = refUsageByPath?.get(refId) ?? []
+    const claims = Array.from(new Set(usages.map(u => (u.excerpt || '').trim()).filter(Boolean))).slice(0, maxExcerpts)
+    if (claims.length === 0) {
+      // Nothing was attributed to this ref in the prose — there is no claim to
+      // check. Keep it (the Pass-2 reconstruction path lands here) and count it.
+      unverifiableRefIds.push(refId)
+      continue
+    }
+
+    const guidelineText = guidelineTextForRef(ragContext, refId, maxChunkChars)
+    if (!guidelineText) {
+      unverifiableRefIds.push(refId)
+      continue
+    }
+
+    items.push({
+      ref_id: refId,
+      title: ref.title || 'Untitled guideline',
+      source: ref.source || 'UNKNOWN',
+      guideline_text: guidelineText,
+      claims,
+    })
+  }
+
+  if (unverifiableRefIds.length > 0) {
+    console.warn(
+      `${tag} ${unverifiableRefIds.length} ref(s) kept WITHOUT verification — no narrative claim attached: ` +
+        unverifiableRefIds.join(', '),
+    )
+  }
+
+  if (items.length === 0) {
+    return {
+      ...base,
+      unverifiableRefIds,
+      skippedReason: 'no-verifiable-claims',
+      latencyMs: Date.now() - t0,
+    }
+  }
+
+  console.log(`${tag} Verifying ${items.length} citation(s) against guideline text…`)
+
+  const verdicts: CitationVerdict[] = []
+  try {
+    // Model resolution: explicit override → RAG_VERIFY_MODEL (lets a
+    // deployment point this auxiliary pass at a cheap fast variant) → the
+    // standard callLLM env resolution.
+    const modelOverride = options.model ?? process.env.RAG_VERIFY_MODEL ?? undefined
+    const result = await callLLM({
+      useCase: 'RAG_VERIFY',
+      messages: [
+        { role: 'system', content: SYSTEM_PROMPT },
+        { role: 'user', content: JSON.stringify({ items }, null, 2) },
+      ],
+      maxTokens: 1200,
+      responseFormat: 'json_object',
+      reasoningEffort: 'none',
+      timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+      ...(modelOverride ? { model: modelOverride } : {}),
+    })
+
+    let parsed: { verdicts?: unknown }
+    try {
+      parsed = JSON.parse(result.text || '{}')
+    } catch (parseErr: any) {
+      console.warn(`${tag} JSON parse failed (${parseErr?.message || parseErr}) — keeping all citations`)
+      return { ...base, unverifiableRefIds, skippedReason: 'parse-error', latencyMs: Date.now() - t0 }
+    }
+
+    if (!Array.isArray(parsed.verdicts) || parsed.verdicts.length === 0) {
+      console.warn(`${tag} No verdicts returned — keeping all citations`)
+      return { ...base, unverifiableRefIds, skippedReason: 'empty-verdicts', latencyMs: Date.now() - t0 }
+    }
+
+    const knownIds = new Set(items.map(i => i.ref_id))
+    for (const raw of parsed.verdicts as any[]) {
+      const refId = String(raw?.ref_id || '').replace(/^\[(.+)\]$/, '$1').trim()
+      if (!refId || !knownIds.has(refId)) continue
+      verdicts.push({
+        ref_id: refId,
+        // Anything that is not an explicit `false` counts as supported.
+        supported: raw?.supported !== false,
+        reason: String(raw?.reason || '').slice(0, 120),
+      })
+    }
+  } catch (err: any) {
+    console.warn(`${tag} Verification call failed (${err?.message || err}) — keeping all citations`)
+    return { ...base, unverifiableRefIds, skippedReason: 'call-failed', latencyMs: Date.now() - t0 }
+  }
+
+  if (verdicts.length === 0) {
+    console.warn(`${tag} No usable verdict matched a known ref — keeping all citations`)
+    return { ...base, unverifiableRefIds, skippedReason: 'no-matching-verdicts', latencyMs: Date.now() - t0 }
+  }
+
+  const removedRefIds = verdicts.filter(v => !v.supported).map(v => v.ref_id)
+
+  for (const v of verdicts) {
+    console.log(`${tag} [${v.ref_id}] ${v.supported ? '✅ supported' : '❌ UNSUPPORTED'} — ${v.reason || 'no reason given'}`)
+  }
+
+  if (removedRefIds.length === 0) {
+    console.log(`${tag} All ${verdicts.length} verified citation(s) grounded — nothing removed`)
+    return {
+      evidenceReferences: refs,
+      removedRefIds: [],
+      verdicts,
+      verified: true,
+      tokensStripped: 0,
+      unverifiableRefIds,
+      latencyMs: Date.now() - t0,
+    }
+  }
+
+  // Remove the markers from the prose. The prose itself is left intact — an
+  // unsupported citation means the sentence is unsourced, not wrong.
+  const removeSet = new Set(removedRefIds)
+  const counter = { n: 0 }
+  stripRefTokens(analysis, removeSet, counter)
+
+  // Drop the entries from the model's own evidence_references array too, so a
+  // downstream consumer reading `analysis` directly stays consistent with the
+  // returned bibliography.
+  if (Array.isArray(analysis?.evidence_references)) {
+    analysis.evidence_references = analysis.evidence_references.filter((entry: any) => {
+      const id = String(entry?.ref_id || '').replace(/^\[(.+)\]$/, '$1').trim()
+      return !removeSet.has(id)
+    })
+  }
+
+  const kept = refs.filter(r => !removeSet.has(String(r?.ref_id || '').trim()))
+
+  console.warn(
+    `${tag} Removed ${removedRefIds.length} unsupported citation(s): ${removedRefIds.join(', ')} ` +
+      `(${counter.n} [ref-N] token(s) stripped from the narrative; prose left unchanged). ` +
+      `Bibliography: ${refs.length} → ${kept.length}.`,
+  )
+  if (kept.length === 0) {
+    console.warn(
+      `${tag} Bibliography is now EMPTY — every verified citation was judged unsupported. ` +
+        `The report stands on clinical practice alone, which is the correct outcome when no ` +
+        `retrieved guideline backs its claims.`,
+    )
+  }
+
+  return {
+    evidenceReferences: kept,
+    removedRefIds,
+    verdicts,
+    verified: true,
+    tokensStripped: counter.n,
+    unverifiableRefIds,
+    latencyMs: Date.now() - t0,
+  }
+}


### PR DESCRIPTION
Objectif : qu'un compte rendu soit **sourcé sans hallucination**. Deux commits, deux défauts distincts.

## Le point de départ

La chaîne RAG verrouillait l'**identité** d'une référence, pas son **appariement** ni son **statut**.

Déjà garanti avant cette PR : un `[ref-N]` hors plage est retiré ; une référence listée mais non citée est écartée ; titre, source, URL et date sont joints depuis la ligne du corpus, jamais fournis par le modèle — **un lien fabriqué est impossible par construction**.

Ce qu'aucun contrôle ne faisait : lire le **texte** de la guideline. Le scrub raisonne sur la plage d'identifiants, le filtre thématique sur le titre. `chunk_content` n'était lu que pour construire le prompt et re-classer.

---

## Commit 1 — Vérification d'appariement

`lib/rag/verify-citations.ts`, exécuté en dernier, quand la bibliographie ne compte plus que 2 à 6 références : **un seul appel LLM par consultation**. Pour chaque référence, le texte réel de la guideline et les extraits exacts du rapport où `[ref-N]` a été posé, et une seule question — ce texte porte-t-il sur ces affirmations ?

Le défaut fermé est invisible dans les journaux : une recommandation NICE / CDC / ESC authentique, correctement récupérée, correctement liée, accolée à une posologie qu'elle ne contient pas. Le lecteur voit une source faisant autorité à côté d'une affirmation qu'elle ne soutient pas — pire qu'une absence de citation, puisque la référence prête son autorité à ce qu'elle n'a jamais dit.

**Trois choix structurants :**

- **Asymétrie assumée.** Le vérificateur répond « soutenu » par défaut ; seul un refus explicite retire quelque chose. Écarter une citation légitime fait passer un rapport fondé pour non sourcé ; garder une citation fausse fait passer une affirmation non fondée pour sourcée. La passe arrive après trois filtres — ce qui l'atteint est déjà plausible, elle ne tranche que les écarts nets.
- **Seuls les marqueurs et l'entrée bibliographique sont retirés.** La prose clinique n'est jamais modifiée. Une citation non soutenue signifie « cette phrase n'est pas sourcée par cette guideline », pas « cette phrase est fausse ».
- **Fail-open**, comme la récupération et le re-classement.

---

## Commit 2 — Statut des sources, Pass 2, filtre thématique

### Mesure sur le corpus réel (`tibok-production`, 6 315 documents)

| Nature | Documents | Part |
|---|---|---|
| `referentiel` — porte un langage de recommandation | 2 092 | 33 % |
| `recherche` — rapporte une étude | 2 019 | **32 %** |
| `indetermine` | 1 425 | 23 % |
| `notice` — texte intégral jamais récupéré | 779 | **12 %** |

**~44 % de ce que ce pipeline peut citer n'est pas une recommandation de société savante** — et tout était présenté sous le même intitulé « guidelines médicales internationales ». Un document titré « CHEST guideline » dont le texte décrit une cohorte de 53 patients donnait une citation ayant l'apparence de l'autorité d'une société savante sans en avoir le statut.

**1. Étiquetage des sources.** Lecture de `guideline_content_kind` sur les seules guidelines retenues, avec repli sur la détection des notices — qui se déclarent dans leur propre texte — quand la table ne rend rien. L'avertissement est porté **dans le bloc de prompt**, au plus près de l'extrait, et une règle 10 interdit de citer une étude comme une recommandation ou d'attribuer un chiffre à une notice. Côté rapport, une pastille signale les sources qui ne sont pas des référentiels ; le cas normal n'est pas pastillé.

Branché sur les **deux points d'entrée de récupération**, donc acquis pour les cinq routes — une route ne peut pas l'oublier. La dermatologie le rejoue après sa fusion par titre, qui est synchrone et contourne ces points d'entrée.

N'écarte rien : un article de recherche a sa place dans un raisonnement clinique, il n'a simplement pas le statut d'un référentiel et le compte rendu doit le dire.

**2. Pass 2 fermé.** La reconstruction listait **toutes** les références récupérées quand le modèle n'avait cité nulle part — le lecteur voyait des sources présentées comme ayant fondé le raisonnement alors qu'aucune n'y avait servi. C'est la même attribution fabriquée qui avait fait retirer le Pass 3, en plus discret : le Pass 3 complétait une liste partielle, cette branche inventait la liste entière. Seules les références réellement citées dans la prose sont désormais reconstruites. Un rapport écrit sans citer est un rapport fondé sur la pratique clinique, et le dire est la sortie honnête.

**3. Filtre thématique sur la consultation générale.** Les quatre autres flux qui citent l'appliquaient déjà. Il manquait au flux le plus utilisé, et précisément celui dont le prompt pousse le plus à citer (« MINIMUM 3 références », « en cas de doute, PRÉFÈRE citer »).

---

## État final du verrouillage

| Un rapport peut-il… | Avant | Après |
|---|---|---|
| inventer un lien / titre / URL | non | non |
| citer un `[ref-N]` inexistant | non | non |
| lister une référence jamais citée | **oui** | non |
| citer une guideline hors sujet (consultation générale) | **oui** | non |
| citer une guideline qui ne dit pas ça | **oui** | non |
| faire passer une étude pour une recommandation | **oui** | non |
| attribuer un chiffre à une notice non lue | **oui** | non |

## Portée

| Route | Filtre thématique | Vérification |
|---|---|---|
| `openai-diagnosis` | ajouté ici | ✅ |
| `dermatology-diagnosis` | existant | ✅ |
| `chronic-diagnosis` | existant | ✅ |
| `chronic-examens` | existant | ✅ (avant l'auto-citation défensive, qui ne peut donc plus retomber sur une référence écartée) |
| `chronic-prescription` | existant | ✅ |

Compteurs remontés dans `rag_metadata` : `grounding_verified`, `unsupported_refs_removed`, `unsupported_refs_breakdown`, `unverifiable_refs`, `grounding_verdicts`, `grounding_latency_ms`. Le nombre de fausses attributions était jusqu'ici non mesurable ; il devient observable en production.

`RAG_VERIFY_MODEL` permet de pointer la passe de vérification vers une variante rapide sans redéploiement.

## Vérification

- `tsc --noEmit` : **10 erreurs avant, 10 après**, toutes dans `components/MedicalAIAssistant.tsx` et `lib/medical/clinical-scores.ts` — préexistantes, aucun fichier touché ici. Zéro erreur de type introduite.
- Signature de la RPC vérifiée sur la base : `match_guidelines` projette bien `guideline_id`. Le champ reste optionnel côté code — un déploiement dont la RPC le supprimerait dégrade vers « non étiqueté » au lieu de planter.
- Logique validée sur harnais : retrait des marqueurs (dont `ref-1` qui ne doit pas correspondre à `ref-12`, préservation de la prose, non-parcours de `evidence_references`, absence de parenthèses vides), sélection du Pass 2, résolution du statut, détection des notices, politique de pastilles.
- ⚠️ La suite `npm test` est **cassée en amont** : 8 échecs sur 8 sur `main` (Node 22 sans loader TypeScript). Aucun test n'a été ajouté à une suite qui ne s'exécute pas — la validation ci-dessus a été faite hors suite.
- ⚠️ **Pas de test d'intégration bout en bout** : la passe de vérification appelle un LLM, elle n'a pas été exercée sur une consultation réelle.

## Hors périmètre, à la demande explicite

Deux points identifiés lors de l'analyse et **volontairement non traités** — ce sont des défauts de cohérence ou de couverture, pas de véracité : rien de faux n'est affiché dans un cas comme dans l'autre.

- Le parcours chronique fait trois récupérations RAG pour une seule bibliographie affichée (celle du diagnostic).
- Le suivi chronique (`chronic-follow-up-report`, `follow-ups/doctor-summary`) n'utilise pas le RAG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Uo5KqK2nhvipY8XvijH7ZX